### PR TITLE
fix: convert the pointer values of type uchar to unsafe.Pointer before converting them to *char

### DIFF
--- a/v4l2/capability.go
+++ b/v4l2/capability.go
@@ -126,9 +126,9 @@ func GetCapability(fd uintptr) (Capability, error) {
 		return Capability{}, fmt.Errorf("capability: %w", err)
 	}
 	return Capability{
-		Driver:             C.GoString((*C.char)(&v4l2Cap.driver[0])),
-		Card:               C.GoString((*C.char)(&v4l2Cap.card[0])),
-		BusInfo:            C.GoString((*C.char)(&v4l2Cap.bus_info[0])),
+		Driver:             C.GoString((*C.char)(unsafe.Pointer(&v4l2Cap.driver[0]))),
+		Card:               C.GoString((*C.char)(unsafe.Pointer(&v4l2Cap.card[0]))),
+		BusInfo:            C.GoString((*C.char)(unsafe.Pointer(&v4l2Cap.bus_info[0]))),
 		Version:            uint32(v4l2Cap.version),
 		Capabilities:       uint32(v4l2Cap.capabilities),
 		DeviceCapabilities: uint32(v4l2Cap.device_caps),

--- a/v4l2/format_desc.go
+++ b/v4l2/format_desc.go
@@ -73,7 +73,7 @@ func makeFormatDescription(fmtDesc C.struct_v4l2_fmtdesc) FormatDescription {
 		Index:       uint32(fmtDesc.index),
 		StreamType:  uint32(fmtDesc._type),
 		Flags:       uint32(fmtDesc.flags),
-		Description: C.GoString((*C.char)(&fmtDesc.description[0])),
+		Description: C.GoString((*C.char)(unsafe.Pointer(&fmtDesc.description[0]))),
 		PixelFormat: uint32(fmtDesc.pixelformat),
 		MBusCode:    uint32(fmtDesc.mbus_code),
 	}

--- a/v4l2/video_info.go
+++ b/v4l2/video_info.go
@@ -49,7 +49,7 @@ func (i InputInfo) GetIndex() uint32 {
 }
 
 func (i InputInfo) GetName() string {
-	return C.GoString((*C.char)(&i.v4l2Input.name[0]))
+	return C.GoString((*C.char)(unsafe.Pointer(&i.v4l2Input.name[0])))
 }
 
 func (i InputInfo) GetInputType() InputType {


### PR DESCRIPTION
Signed-off-by: Felix Ting <felix@iotechsys.com>