### PR TITLE
Fix for memory leak in stream loop

### DIFF
--- a/examples/webcam/webcam.go
+++ b/examples/webcam/webcam.go
@@ -52,7 +52,8 @@ func serveVideoStream(w http.ResponseWriter, req *http.Request) {
 	w.Header().Set("Content-Type", fmt.Sprintf("multipart/x-mixed-replace; boundary=%s", boundaryName))
 	w.WriteHeader(http.StatusOK)
 
-	for frame := range frames {
+	var frame []byte
+	for frame = range frames {
 		if len(frame) == 0 {
 			log.Print("skipping empty frame")
 			continue

--- a/v4l2/streaming.go
+++ b/v4l2/streaming.go
@@ -54,7 +54,6 @@ type RequestBuffers struct {
 // after streaming IO has been initialized.
 // https://www.kernel.org/doc/html/latest/userspace-api/media/v4l/buffer.html#c.V4L.v4l2_buffer
 // https://elixir.bootlin.com/linux/latest/source/include/uapi/linux/videodev2.h#L1037
-//
 type Buffer struct {
 	Index     uint32
 	Type      uint32
@@ -103,7 +102,6 @@ type BufferInfo struct {
 // Plane (see struct v4l2_plane) represents a plane in a multi-planar buffers
 // https://www.kernel.org/doc/html/latest/userspace-api/media/v4l/buffer.html#c.V4L.v4l2_plane
 // https://elixir.bootlin.com/linux/latest/source/include/uapi/linux/videodev2.h#L990
-//
 type Plane struct {
 	BytesUsed  uint32
 	Length     uint32
@@ -261,20 +259,4 @@ func DequeueBuffer(fd uintptr, ioType IOType, bufType BufType) (Buffer, error) {
 	}
 
 	return makeBuffer(v4l2Buf), nil
-}
-
-// CaptureBuffer captures a frame buffer from the device
-func CaptureBuffer(fd uintptr, ioType IOType, bufType BufType) (Buffer, error) {
-	bufInfo, err := DequeueBuffer(fd, ioType, bufType)
-	if err != nil {
-		return Buffer{}, fmt.Errorf("capture frame: dequeue: %w", err)
-	}
-
-	// requeue/clear used buffer, prepare for next read
-	if _, err := QueueBuffer(fd, ioType, bufType, bufInfo.Index); err != nil {
-		return Buffer{}, fmt.Errorf("capture frame: queue: %w", err)
-	}
-
-	// return captured buffer
-	return bufInfo, nil
 }

--- a/v4l2/streaming_loop.go
+++ b/v4l2/streaming_loop.go
@@ -4,12 +4,12 @@ import (
 	sys "golang.org/x/sys/unix"
 )
 
+// WaitForRead returns a channel that can be used to be notified when
+// a device's is ready to be read.
 func WaitForRead(dev Device) <-chan struct{} {
 	sigChan := make(chan struct{})
 
-	fd := dev.Fd()
-
-	go func() {
+	go func(fd uintptr) {
 		defer close(sigChan)
 		var fdsRead sys.FdSet
 		fdsRead.Set(int(fd))
@@ -22,7 +22,7 @@ func WaitForRead(dev Device) <-chan struct{} {
 			}
 			sigChan <- struct{}{}
 		}
-	}()
+	}(dev.Fd())
 
 	return sigChan
 }


### PR DESCRIPTION
This PR fixes a memory leak  reported when running the webcam example. After profiling, the leak was identified in the loop for streaming captured from from the device. Specifically, the fix simply moved the v4l2.WaitForRead function call out of the loop.

### Fix
Prior to the fix, the webcam process would be killed, after about an hour of running, by the OS to prevent an OOM situation. After the fix, the followings were observed:

* Webcam process only used 1% of memory after 5 hours of running
* Webcam process never crashed or killed
* After opening 8 concurrent browser tabs, receiving  30 frames of HD video per second, the memory profile stayed the same

Fixes #22  