### PR TITLE
fix(Camera): goroutine leak

### DIFF
--- a/examples/webcam/README.md
+++ b/examples/webcam/README.md
@@ -70,7 +70,7 @@ Usage of ./webcam:
 ```
 
 ## The source code
-The following code walkthrough illustrates how simple it is to create programs that can stream video using the `go4vl` project.
+The following code walk-through illustrates how simple it is to create programs that can stream video using the `go4vl` project.
 
 Firstly, the `main` function opens the video device with a set of specified configurations (from CLI flags):
 
@@ -162,4 +162,4 @@ func serveVideoStream(w http.ResponseWriter, req *http.Request) {
 }
 ```
 
-> See the full source code [here](./webcam.go)
+>See the full source code [here](./webcam.go)

--- a/v4l2/syscalls.go
+++ b/v4l2/syscalls.go
@@ -88,8 +88,8 @@ func send(fd, req, arg uintptr) error {
 
 // WaitForRead returns a channel that can be used to be notified when
 // a device's is ready to be read.
-func WaitForRead(dev Device, doneChan chan struct{}) <-chan struct{} {
-	sigChan := make(chan struct{}, 1)
+func WaitForRead(dev Device) <-chan struct{} {
+	sigChan := make(chan struct{})
 
 	go func(fd uintptr) {
 		defer close(sigChan)
@@ -102,11 +102,7 @@ func WaitForRead(dev Device, doneChan chan struct{}) <-chan struct{} {
 				continue
 			}
 
-			select {
-			case sigChan <- struct{}{}:
-			case <-doneChan:
-				return
-			}
+			sigChan <- struct{}{}
 		}
 	}(dev.Fd())
 


### PR DESCRIPTION
This fixes two goroutine leaks:
- in regular streaming mode goroutines kept building up very fast.
- stopping the camera did not get rid of all goroutines.