### PR TITLE
Refactor: get rid of reflect package

### DIFF
--- a/device/device.go
+++ b/device/device.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"reflect"
 	sys "syscall"
 
 	"github.com/vladimirvivien/go4vl/v4l2"
@@ -52,7 +51,7 @@ func Open(path string, options ...Option) (*Device, error) {
 	dev.cap = cap
 
 	// set preferred device buffer size
-	if reflect.ValueOf(dev.config.bufSize).IsZero() {
+	if dev.config.bufSize == 0 {
 		dev.config.bufSize = 2
 	}
 
@@ -75,7 +74,7 @@ func Open(path string, options ...Option) (*Device, error) {
 		return nil, fmt.Errorf("device open: %s: %w", path, v4l2.ErrorUnsupportedFeature)
 	}
 
-	if !reflect.ValueOf(dev.config.bufType).IsZero() && dev.config.bufType != dev.bufType {
+	if dev.config.bufType != 0 && dev.config.bufType != dev.bufType {
 		return nil, fmt.Errorf("device open: does not support buffer stream type")
 	}
 
@@ -90,7 +89,7 @@ func Open(path string, options ...Option) (*Device, error) {
 	}
 
 	// set pix format
-	if !reflect.ValueOf(dev.config.pixFormat).IsZero() {
+	if !dev.config.pixFormat.IsZero() {
 		if err := dev.SetPixFormat(dev.config.pixFormat); err != nil {
 			return nil, fmt.Errorf("device open: %s: set format: %w", path, err)
 		}
@@ -102,7 +101,7 @@ func Open(path string, options ...Option) (*Device, error) {
 	}
 
 	// set fps
-	if !reflect.ValueOf(dev.config.fps).IsZero() {
+	if dev.config.fps != 0 {
 		if err := dev.SetFrameRate(dev.config.fps); err != nil {
 			return nil, fmt.Errorf("device open: %s: set fps: %w", path, err)
 		}
@@ -200,7 +199,7 @@ func (d *Device) GetPixFormat() (v4l2.PixFormat, error) {
 		return v4l2.PixFormat{}, v4l2.ErrorUnsupportedFeature
 	}
 
-	if reflect.ValueOf(d.config.pixFormat).IsZero() {
+	if d.config.pixFormat.IsZero() {
 		pixFmt, err := v4l2.GetPixFormat(d.fd)
 		if err != nil {
 			return v4l2.PixFormat{}, fmt.Errorf("device: %w", err)
@@ -300,7 +299,7 @@ func (d *Device) SetFrameRate(fps uint32) error {
 
 // GetFrameRate returns the FPS value for the device
 func (d *Device) GetFrameRate() (uint32, error) {
-	if reflect.ValueOf(d.config.fps).IsZero() {
+	if d.config.fps == 0 {
 		param, err := d.GetStreamParam()
 		if err != nil {
 			return 0, fmt.Errorf("device: frame rate: %w", err)

--- a/device/device.go
+++ b/device/device.go
@@ -89,7 +89,7 @@ func Open(path string, options ...Option) (*Device, error) {
 	}
 
 	// set pix format
-	if !dev.config.pixFormat.IsZero() {
+	if dev.config.pixFormat != (v4l2.PixFormat{}) {
 		if err := dev.SetPixFormat(dev.config.pixFormat); err != nil {
 			return nil, fmt.Errorf("device open: %s: set format: %w", path, err)
 		}
@@ -199,7 +199,7 @@ func (d *Device) GetPixFormat() (v4l2.PixFormat, error) {
 		return v4l2.PixFormat{}, v4l2.ErrorUnsupportedFeature
 	}
 
-	if d.config.pixFormat.IsZero() {
+	if d.config.pixFormat == (v4l2.PixFormat{}) {
 		pixFmt, err := v4l2.GetPixFormat(d.fd)
 		if err != nil {
 			return v4l2.PixFormat{}, fmt.Errorf("device: %w", err)

--- a/v4l2/format.go
+++ b/v4l2/format.go
@@ -278,6 +278,10 @@ func (f PixFormat) String() string {
 	)
 }
 
+func (f PixFormat) IsZero() bool {
+	return f == PixFormat{}
+}
+
 // GetPixFormat retrieves pixel information for the specified driver (via v4l2_format and v4l2_pix_format)
 // See https://elixir.bootlin.com/linux/latest/source/include/uapi/linux/videodev2.h#L2331
 // and https://www.kernel.org/doc/html/latest/userspace-api/media/v4l/vidioc-g-fmt.html#ioctl-vidioc-g-fmt-vidioc-s-fmt-vidioc-try-fmt

--- a/v4l2/format.go
+++ b/v4l2/format.go
@@ -278,10 +278,6 @@ func (f PixFormat) String() string {
 	)
 }
 
-func (f PixFormat) IsZero() bool {
-	return f == PixFormat{}
-}
-
 // GetPixFormat retrieves pixel information for the specified driver (via v4l2_format and v4l2_pix_format)
 // See https://elixir.bootlin.com/linux/latest/source/include/uapi/linux/videodev2.h#L2331
 // and https://www.kernel.org/doc/html/latest/userspace-api/media/v4l/vidioc-g-fmt.html#ioctl-vidioc-g-fmt-vidioc-s-fmt-vidioc-try-fmt


### PR DESCRIPTION
This PR replaces `reflect` package in `device/device.go` with more simple language constructs.