### PR TITLE
Fix typo and grammar issues in comments

### DIFF
--- a/device/device_control.go
+++ b/device/device_control.go
@@ -15,7 +15,7 @@ func (d *Device) GetControl(ctrlID v4l2.CtrlID) (v4l2.Control, error) {
 	return ctlr, nil
 }
 
-// SetControl updates the value of the specified control id.
+// SetControlValue updates the value of the specified control id.
 func (d *Device) SetControlValue(ctrlID v4l2.CtrlID, val v4l2.CtrlValue) error {
 	err := v4l2.SetControlValue(d.fd, ctrlID, val)
 	if err != nil {

--- a/examples/cgo_types/cgo_capture.go
+++ b/examples/cgo_types/cgo_capture.go
@@ -123,7 +123,7 @@ func reqBuffers(fd uintptr, count uint32) error {
 
 // ================================ Map device Memory ===============================
 
-// buffer service is embedded uion m
+// BufferService is embedded union m
 // in v4l2_buffer C type.
 type BufferService struct {
 	Offset  uint32
@@ -132,7 +132,7 @@ type BufferService struct {
 	FD      int32
 }
 
-// mamapBuffer first queries the status of the device buffer at idx
+// mmapBuffer first queries the status of the device buffer at idx
 // by retrieving BufferInfo which returns the length of the buffer and
 // the current offset of the allocated buffers.  That information is
 // used to map the device's buffer unto the application's address space.
@@ -173,7 +173,7 @@ func startStreaming(fd uintptr) error {
 
 // ======================== Queue/Dequeue device buffer =======================
 
-// queueBuffer requests that an emptty buffer is enqueued into the device's
+// queueBuffer requests that an empty buffer is enqueued into the device's
 // incoming queue at the specified index (so that it can be filled later).
 func queueBuffer(fd uintptr, idx uint32) error {
 	var v4l2Buf C.struct_v4l2_buffer
@@ -292,7 +292,7 @@ func main() {
 		log.Fatalf("failed during device read-wait: %s", err)
 	}
 
-	// deqeue the device buffer so that the local mapped byte slice
+	// dequeue the device buffer so that the local mapped byte slice
 	// is filled.
 	bufSize, err := dequeueBuffer(fd)
 	if err != nil {

--- a/examples/manual_types/v4l2_capture.go
+++ b/examples/manual_types/v4l2_capture.go
@@ -15,7 +15,7 @@ import (
 // https://elixir.bootlin.com/linux/v5.13-rc6/source/include/uapi/asm-generic/ioctl.h
 
 const (
-	//ioctl command layout
+	// ioctl command layout
 	iocNone  = 0 // no op
 	iocWrite = 1 // userland app is writing, kernel reading
 	iocRead  = 2 // userland app is reading, kernel writing
@@ -91,7 +91,7 @@ const (
 // https://elixir.bootlin.com/linux/v5.13-rc6/source/include/uapi/linux/videodev2.h#L2324
 type Format struct {
 	StreamType uint32
-	fmt        [200]byte // max uinion size
+	fmt        [200]byte // max union size
 }
 
 // PixFormat represents v4l2_pix_format
@@ -187,7 +187,7 @@ type BufferInfo struct {
 	RequestFD  int32
 }
 
-// buffer service is embedded uion m
+// BufferService is embedded union m
 // in v4l2_buffer C type.
 type BufferService struct {
 	Offset  uint32
@@ -208,7 +208,7 @@ type Timecode struct {
 	Userbits [4]uint8
 }
 
-// mamapBuffer first queries the status of the device buffer at idx
+// mmapBuffer first queries the status of the device buffer at idx
 // by retrieving BufferInfo which returns the length of the buffer and
 // the current offset of the allocated buffers.  That information is
 // used to map the device's buffer unto the application's address space.
@@ -252,7 +252,7 @@ func startStreaming(fd uintptr) error {
 
 // ======================== Queue/Dequeue device buffer =======================
 
-// queueBuffer requests that an emptty buffer is enqueued into the device's
+// queueBuffer requests that an empty buffer is enqueued into the device's
 // incoming queue at the specified index (so that it can be filled later).
 func queueBuffer(fd uintptr, idx uint32) error {
 	buf := BufferInfo{
@@ -368,7 +368,7 @@ func main() {
 		log.Fatalf("failed during device read-wait: %s", err)
 	}
 
-	// deqeue the device buffer so that the local mapped byte slice
+	// dequeue the device buffer so that the local mapped byte slice
 	// is filled.
 	bufSize, err := dequeueBuffer(fd)
 	if err != nil {

--- a/v4l2/control.go
+++ b/v4l2/control.go
@@ -11,7 +11,7 @@ import (
 	"unsafe"
 )
 
-// ControlValue represents the value for a user control.
+// CtrlValue represents the value for a user control.
 // See https://www.kernel.org/doc/html/latest/userspace-api/media/v4l/control.html
 // See https://elixir.bootlin.com/linux/latest/source/include/uapi/linux/videodev2.h#L1740
 type CtrlValue = int32
@@ -121,7 +121,7 @@ func QueryControlInfo(fd uintptr, id CtrlID) (Control, error) {
 	return control, nil
 }
 
-// GetControl retrieves the value and information for the user control witht he specified id.
+// GetControl retrieves the value and information for the user control with the specified id.
 // See https://www.kernel.org/doc/html/latest/userspace-api/media/v4l/control.html
 func GetControl(fd uintptr, id CtrlID) (Control, error) {
 	control, err := QueryControlInfo(fd, id)

--- a/v4l2/control_values.go
+++ b/v4l2/control_values.go
@@ -7,7 +7,7 @@ package v4l2
 */
 import "C"
 
-// ControlClass
+// CtrlClass
 // See https://elixir.bootlin.com/linux/latest/source/include/uapi/linux/v4l2-controls.h#L56
 type CtrlClass = uint32
 
@@ -80,7 +80,7 @@ const (
 // CtrlID type for control values
 type CtrlID = uint32
 
-// Powerline frequency control enums
+// PowerlineFrequency control enums
 // See https://elixir.bootlin.com/linux/latest/source/include/uapi/linux/v4l2-controls.h#L100
 type PowerlineFrequency = uint32
 
@@ -91,7 +91,7 @@ const (
 	PowerlineFrequencyAuto     PowerlineFrequency = C.V4L2_CID_POWER_LINE_FREQUENCY_AUTO
 )
 
-// Color FX control enums
+// ColorFX control enums
 // See https://elixir.bootlin.com/linux/latest/source/include/uapi/linux/v4l2-controls.h#L114
 type ColorFX = uint32
 

--- a/v4l2/ext_controls.go
+++ b/v4l2/ext_controls.go
@@ -47,7 +47,7 @@ func SetExtControlValue(fd uintptr, id CtrlID, val CtrlValue) error {
 	return nil
 }
 
-// SetExtControls implements code to save one or more extended controls at once using the
+// SetExtControlValues implements code to save one or more extended controls at once using the
 // v4l2_ext_controls structure.
 // https://linuxtv.org/downloads/v4l-dvb-apis-new/userspace-api/v4l/extended-controls.html
 // See https://elixir.bootlin.com/linux/latest/source/include/uapi/linux/videodev2.h#L1774
@@ -109,7 +109,7 @@ func QueryExtControlInfo(fd uintptr, id CtrlID) (Control, error) {
 	return control, nil
 }
 
-// QueryExtAllControls loop through all available ext controls and query the information for
+// QueryAllExtControls loop through all available ext controls and query the information for
 // all controls without their current values (use GetExtControlValue to get current values).
 func QueryAllExtControls(fd uintptr) (result []Control, err error) {
 

--- a/v4l2/format_framesizes.go
+++ b/v4l2/format_framesizes.go
@@ -20,7 +20,7 @@ const (
 	FrameSizeTypeStepwise   FrameSizeType = C.V4L2_FRMSIZE_TYPE_STEPWISE
 )
 
-// FrameSizeEnum uses v4l2_frmsizeenum to get supporeted frame size for the driver based for the pixel format.
+// FrameSizeEnum uses v4l2_frmsizeenum to get supported frame size for the driver based for the pixel format.
 // Use FrameSizeType to determine which sizes the driver support.
 // https://elixir.bootlin.com/linux/latest/source/include/uapi/linux/videodev2.h#L829
 // https://www.kernel.org/doc/html/latest/userspace-api/media/v4l/vidioc-enum-framesizes.html

--- a/v4l2/stream_param.go
+++ b/v4l2/stream_param.go
@@ -8,7 +8,7 @@ import (
 	"unsafe"
 )
 
-// Flags for capability and capture mode fields
+// StreamParamFlag is for capability and capture mode fields
 // See https://linuxtv.org/downloads/v4l-dvb-apis/userspace-api/v4l/vidioc-g-parm.html#parm-flags
 // See https://elixir.bootlin.com/linux/latest/source/include/uapi/linux/videodev2.h#L1214
 type StreamParamFlag = uint32

--- a/v4l2/streaming.go
+++ b/v4l2/streaming.go
@@ -136,8 +136,8 @@ type Plane struct {
 	DataOffset uint32
 }
 
-// PlaneInfo representes the combination of type
-// of type of memory stream that can be serviced for the
+// PlaneInfo represents the combination of type
+// of memory stream that can be serviced for the
 // associated plane.
 type PlaneInfo struct {
 	MemOffset uint32


### PR DESCRIPTION
This PR fixes comments:
- add whitespaces after `//`;
- typos (`deqeue` -> `dequeue`, `uion` -> `union`, `mamap` -> `mmap` etc.);
- fix the first word in a comment to match the variable's or function's name (`SetControl` -> `SetControlValue`, `ControlValue` -> `CtrlValue` etc.).