### PR TITLE
timeout and fdSet need to be set on each loop iteration as select() can modify them on linux

### DIFF
--- a/v4l2/syscalls.go
+++ b/v4l2/syscalls.go
@@ -98,8 +98,13 @@ func WaitForRead(dev Device) <-chan struct{} {
 			fdsRead.Zero()
 			fdsRead.Set(int(fd))
 			tv := sys.Timeval{Sec: 2, Usec: 0}
-			_, errno := sys.Select(int(fd+1), &fdsRead, nil, nil, &tv)
+			n, errno := sys.Select(int(fd+1), &fdsRead, nil, nil, &tv)
 			if errno == sys.EINTR {
+				continue
+			}
+
+			if n == 0 {
+				// timeout, no data available
 				continue
 			}
 

--- a/v4l2/syscalls.go
+++ b/v4l2/syscalls.go
@@ -94,9 +94,10 @@ func WaitForRead(dev Device) <-chan struct{} {
 	go func(fd uintptr) {
 		defer close(sigChan)
 		var fdsRead sys.FdSet
-		fdsRead.Set(int(fd))
-		tv := sys.Timeval{Sec: 2, Usec: 0}
 		for {
+			fdsRead.Zero()
+			fdsRead.Set(int(fd))
+			tv := sys.Timeval{Sec: 2, Usec: 0}
 			_, errno := sys.Select(int(fd+1), &fdsRead, nil, nil, &tv)
 			if errno == sys.EINTR {
 				continue


### PR DESCRIPTION
select() will modify the timeout (tv) and fdSet after each call (on linux) and these can drift over time or otherwise get into an unexpected state. They need to be setup before each call to select() as a linux-only work-around. This does that. 