### PR TITLE
Add benchmark infrastructure for performance profiling

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,453 @@
+# go4vl Roadmap
+
+This roadmap outlines the strategic direction and planned enhancements for the go4vl project. The primary goal remains to port as many V4L2 functionalities as possible, providing idiomatic Go types and abstractions for video capture and processing on Linux systems.
+
+## Project Vision
+
+go4vl aims to be the definitive Go library for V4L2 video capture and streaming, enabling developers to build robust video applications on Linux platforms including Raspberry Pi, embedded systems, and standard Linux distributions without dealing with C interop complexities.
+
+---
+
+## Roadmap Summary
+
+- [ ] [1. Frame Processing Pipeline Performance](#1-frame-processing-pipeline-performance)
+- [ ] [2. Migration from CGO to purego](#2-migration-from-cgo-to-purego)
+- [ ] [3. io.Reader/io.Writer Interface Support](#3-ioreaderiowriter-interface-support)
+- [ ] [4. Complete V4L2 Video Capture Feature Parity](#4-complete-v4l2-video-capture-feature-parity)
+- [ ] [5. Multi-Planar Format Support](#5-multi-planar-format-support)
+- [ ] [6. Enhanced Image Format Conversion Library](#6-enhanced-image-format-conversion-library)
+- [ ] [7. User Pointer and DMA-BUF I/O Support](#7-user-pointer-and-dma-buf-io-support)
+- [ ] [8. Video Output Device Support](#8-video-output-device-support)
+- [ ] [9. Advanced Extended Controls API](#9-advanced-extended-controls-api)
+- [ ] [10. Asynchronous Frame Capture with Select/Poll/Epoll](#10-asynchronous-frame-capture-with-selectpollepoll)
+- [ ] [11. Frame Metadata and Timestamping](#11-frame-metadata-and-timestamping)
+- [ ] [12. Hardware Codec Integration (H264, HEVC, VP8, VP9)](#12-hardware-codec-integration-h264-hevc-vp8-vp9)
+- [ ] [13. Media Controller API Integration](#13-media-controller-api-integration)
+- [ ] [14. Performance Optimization and Zero-Copy Enhancements](#14-performance-optimization-and-zero-copy-enhancements)
+- [ ] [15. WASM Component Model Plugin System](#15-wasm-component-model-plugin-system)
+
+---
+
+## Enhancement Details
+
+### 1. **Frame Processing Pipeline Performance**
+
+**Status:** Not Started
+**Goal:** Eliminate bottlenecks in frame processing pipelines to ensure maximum throughput and minimal latency
+
+**Rationale:**
+Frame processing performance is critical for real-time video applications. Bottlenecks can occur at multiple stages: frame capture, memory allocation, channel operations, format conversion, and user processing. Identifying and eliminating these bottlenecks ensures go4vl can handle high-resolution, high-frame-rate scenarios without dropping frames or introducing latency.
+
+**Key Performance Concerns:**
+- Frame copy overhead in the capture loop (currently copies every frame)
+- Channel blocking and buffering strategies
+- Memory allocation patterns and GC pressure
+- Goroutine scheduling and synchronization
+- Lock contention in multi-device scenarios
+- Processing pipeline backpressure handling
+
+**Deliverables:**
+- Comprehensive performance profiling across different resolutions and frame rates
+- Identify and document all bottlenecks in the capture-to-processing pipeline
+- Implement lock-free or low-contention data structures where appropriate
+- Add configurable frame dropping strategies (drop oldest, drop newest, block)
+- Optimize channel buffer sizing and flow control
+- Implement frame pool allocator to reduce GC pressure
+- Add pipeline backpressure detection and handling
+- Create performance monitoring API (dropped frames, latency, throughput)
+- Benchmark suite for different pipeline configurations
+- Add CPU and memory profiling examples
+- Document best practices for high-performance video processing
+- Create reference implementations for common high-throughput scenarios
+
+**Target Performance Metrics:**
+- 1080p @ 60fps with < 5% CPU usage
+- 4K @ 30fps with minimal frame drops
+- Multi-device capture (4+ cameras) without contention
+- Sub-millisecond frame delivery latency
+- Zero frame drops under sustained load
+
+**Profiling and Optimization Areas:**
+- Frame delivery path (device → mmap → copy → channel → user)
+- Buffer lifecycle management
+- Context switching and goroutine overhead
+- Memory allocation patterns
+- Cache-line optimization for hot paths
+
+---
+
+### 2. **Migration from CGO to purego**
+
+**Status:** Not Started
+**Goal:** Eliminate CGO dependency by migrating to pure Go C bindings using the purego library
+
+**Rationale:**
+CGO introduces significant complexity, build overhead, and cross-compilation challenges. It prevents pure Go toolchain benefits like easy cross-compilation, faster builds, and simpler dependency management. The purego library enables calling C functions from pure Go without CGO, making the library more accessible and maintainable.
+
+**Benefits:**
+- Faster compilation times (no C compiler required)
+- Simplified cross-compilation for ARM/ARM64/x86_64
+- Better compatibility with Go's module system
+- Reduced binary size in many cases
+- Easier to contribute (no C toolchain knowledge required)
+- Full support for `go install` without C dependencies
+
+**Deliverables:**
+- Evaluate purego compatibility with V4L2 ioctl operations
+- Create purego-based syscall wrappers for all V4L2 ioctls
+- Migrate struct definitions to pure Go (remove C imports)
+- Update build system to remove CGO requirement
+- Ensure feature parity with current CGO implementation
+- Add CI/CD testing for pure Go builds
+- Update documentation reflecting pure Go approach
+- Create migration guide for existing users
+
+**Challenges:**
+- Complex struct alignment and padding requirements
+- Union type handling in pure Go
+- Performance comparison and optimization
+- Maintaining compatibility across kernel versions
+
+---
+
+### 2. **io.Reader/io.Writer Interface Support**
+
+**Status:** Not Started
+**Goal:** Provide standard io.Reader/io.Writer interfaces alongside existing channel-based API
+
+**Rationale:**
+Channels are idiomatic for concurrent frame delivery, but many Go libraries and tools work with io.Reader/io.Writer interfaces. Supporting both patterns increases composability with the broader Go ecosystem (image processing, encoding, streaming libraries).
+
+**Deliverables:**
+- Implement `io.Reader` interface for frame capture streams
+- Implement `io.Writer` interface for video output devices
+- Add frame framing/deframing for Reader/Writer (handle frame boundaries)
+- Support both blocking and non-blocking I/O modes
+- Create adapter utilities between channel and io interfaces
+- Add examples using io.Reader with standard library (io.Copy, bufio, etc.)
+- Add examples integrating with popular streaming libraries
+- Document performance characteristics of each approach
+- Provide guidance on when to use channels vs io interfaces
+
+**API Design Considerations:**
+- Frame boundary handling in streaming mode
+- Metadata delivery alongside frame data
+- Error handling and EOF semantics
+- Buffer management and zero-copy opportunities
+
+---
+
+### 3. **Complete V4L2 Video Capture Feature Parity**
+
+**Status:** In Progress (significant coverage exists, gaps remain)
+**Goal:** Achieve 100% coverage of V4L2 video capture APIs and capabilities
+
+**Rationale:**
+While go4vl covers core V4L2 functionality, some advanced features remain unimplemented. Complete feature parity ensures users never need to drop to C or use syscall directly.
+
+**Missing Features to Implement:**
+- Selection/Compose API (VIDIOC_G_SELECTION, VIDIOC_S_SELECTION)
+- Video standards enumeration and selection (NTSC, PAL, SECAM)
+- Video timings API for DV and HDMI sources
+- Priority and exclusive access control
+- Advanced cropping capabilities
+- Buffer export/import for cross-device workflows
+- Query extended capabilities flags
+- All buffer timestamp modes
+- Request API support for stateless codecs
+- All field order modes
+- Complete control flags support
+- Menu control integer values
+
+**Deliverables:**
+- Audit current V4L2 API coverage against kernel documentation
+- Implement remaining VIDIOC_* ioctls relevant to video capture
+- Add complete constant definitions for all flags and enums
+- Create comprehensive examples demonstrating each capability
+- Add integration tests for all implemented features
+- Document feature availability by kernel version
+- Create feature detection utilities
+- Update API reference with complete V4L2 mapping
+
+---
+
+### 4. **Multi-Planar Format Support**
+
+**Status:** Not Started
+**Goal:** Add comprehensive support for multi-planar pixel formats (V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE)
+
+**Rationale:**
+Many modern cameras and video processors use multi-planar formats where Y, U, and V components are stored in separate memory planes. This is essential for advanced codec support and high-performance video processing.
+
+**Deliverables:**
+- Implement multi-planar buffer type support in `v4l2/streaming.go`
+- Add multi-planar format descriptors and negotiation
+- Extend `device.Device` to handle planar buffers
+- Create examples demonstrating multi-planar capture
+- Update API documentation with multi-planar usage patterns
+
+---
+
+### 2. **Enhanced Image Format Conversion Library**
+
+**Status:** Partially Implemented (YUYV conversion disabled)
+**Goal:** Complete pixel format conversion utilities for common V4L2 formats
+
+**Rationale:**
+Current `imgsupport` package has disabled YUYV conversion. Users frequently need to convert between raw formats (YUYV, NV12, YV12) and standard image formats (JPEG, PNG) for processing or display.
+
+**Deliverables:**
+- Complete and test YUYV to JPEG/PNG conversion
+- Add NV12, YV12, and I420 format converters
+- Implement RGB format family converters (RGB24, RGB32, BGR24)
+- Add hardware-accelerated conversion paths where available
+- Benchmark and optimize conversion performance
+- Create format conversion example application
+- Document supported conversion paths and performance characteristics
+
+---
+
+### 3. **User Pointer and DMA-BUF I/O Support**
+
+**Status:** Not Started (only MMAP currently supported)
+**Goal:** Implement V4L2_MEMORY_USERPTR and V4L2_MEMORY_DMABUF I/O methods
+
+**Rationale:**
+User pointer mode allows application-allocated buffers, enabling zero-copy integration with other libraries. DMA-BUF support enables zero-copy sharing between V4L2 devices and GPU/display subsystems, critical for high-performance pipelines.
+
+**Deliverables:**
+- Implement `IOTypeUserPtr` support in streaming layer
+- Add user-provided buffer allocation and management
+- Implement `IOTypeDMABuf` for inter-device buffer sharing
+- Add DMA-BUF file descriptor handling and synchronization
+- Create examples for user pointer mode
+- Create examples for DMA-BUF sharing with DRM/KMS
+- Document memory management best practices for each I/O type
+- Add performance comparison benchmarks
+
+---
+
+### 4. **Video Output Device Support**
+
+**Status:** Partially Implemented (output path exists but incomplete)
+**Goal:** Complete implementation for video output devices (V4L2_BUF_TYPE_VIDEO_OUTPUT)
+
+**Rationale:**
+V4L2 supports video output for display devices, video encoders, and hardware accelerators. Currently go4vl primarily focuses on capture. Output support enables frame injection, video encoding pipelines, and display control.
+
+**Deliverables:**
+- Complete `Device.SetInput()` implementation for output devices
+- Add output buffer queue management
+- Implement frame timing control for output
+- Add output format negotiation and validation
+- Create video playback/display examples
+- Create encoder pipeline examples (with hardware encoders)
+- Document output device workflows and use cases
+
+---
+
+### 5. **Advanced Extended Controls API**
+
+**Status:** Basic support implemented
+**Goal:** Comprehensive extended controls with validation, compound controls, and control events
+
+**Rationale:**
+Extended controls enable access to codec parameters, camera sensors, and advanced device features. Current implementation covers basics but lacks compound control support and event notification.
+
+**Deliverables:**
+- Implement compound control support (arrays, structs)
+- Add control event subscription and monitoring (VIDIOC_SUBSCRIBE_EVENT)
+- Implement control priority and error handling improvements
+- Add control validation and bounds checking enhancements
+- Create codec control profiles (H264, VP8, VP9, HEVC)
+- Add camera control presets (exposure, white balance, focus)
+- Create advanced controls example with live adjustment
+- Document control classes and codec-specific parameters
+
+---
+
+### 6. **Asynchronous Frame Capture with Select/Poll/Epoll**
+
+**Status:** Currently uses select internally
+**Goal:** Expose low-level async I/O options for advanced use cases
+
+**Rationale:**
+Current implementation uses `sys.Select` internally but doesn't expose file descriptor for external event loops. Users may want to integrate V4L2 capture into custom event loops or multiplexed I/O systems.
+
+**Deliverables:**
+- Add optional async capture mode with exposed file descriptor
+- Implement epoll support for better scalability with multiple devices
+- Add timeout and deadline control for frame capture
+- Create examples showing integration with Go's context patterns
+- Create example integrating multiple devices in single event loop
+- Document async patterns and best practices
+- Add performance benchmarks comparing async methods
+
+---
+
+### 7. **Frame Metadata and Timestamping**
+
+**Status:** Buffer timestamps exist but not fully exposed
+**Goal:** Comprehensive frame metadata including timestamps, sequence numbers, and flags
+
+**Rationale:**
+Accurate frame timing is critical for video synchronization, frame rate analysis, and time-based processing. Current implementation captures metadata but doesn't expose it through idiomatic interfaces.
+
+**Deliverables:**
+- Create `FrameMetadata` struct with timestamp, sequence, and flags
+- Extend output channel to deliver metadata alongside frames (or add parallel channel)
+- Add frame type detection (keyframe, P-frame, B-frame)
+- Implement frame statistics collection (dropped frames, errors)
+- Add timestamp source configuration and queries
+- Create examples demonstrating frame timing analysis
+- Document synchronization strategies for multi-device capture
+
+---
+
+### 8. **Hardware Codec Integration (H264, HEVC, VP8, VP9)**
+
+**Status:** Basic extended controls exist
+**Goal:** High-level APIs for hardware encoder/decoder configuration
+
+**Rationale:**
+Many platforms (Raspberry Pi, Jetson, modern CPUs) have hardware video codecs accessible via V4L2. Current low-level control support needs higher-level abstractions for practical use.
+
+**Deliverables:**
+- Create codec configuration profiles for H264/HEVC/VP8/VP9
+- Add encoder preset system (quality vs speed trade-offs)
+- Implement bitrate control modes (CBR, VBR, CQP)
+- Add GOP structure configuration helpers
+- Create decoder capabilities query and setup
+- Add examples for hardware encoding (Raspberry Pi H264, etc.)
+- Add examples for hardware decoding
+- Document platform-specific codec availability and capabilities
+- Create codec benchmarking utilities
+
+---
+
+### 9. **Media Controller API Integration**
+
+**Status:** Basic media info query exists
+**Goal:** Full Media Controller API for complex video pipelines
+
+**Rationale:**
+Complex camera systems (CSI-2, MIPI) require Media Controller API to configure sensor, ISP, and capture device topology. Essential for embedded platforms and advanced camera modules.
+
+**Deliverables:**
+- Implement media entity enumeration and topology discovery
+- Implement pipeline setup and validation
+- Add subdevice format negotiation
+- Create CSI-2 camera setup examples (Raspberry Pi Camera Module)
+- Create MIPI camera configuration examples
+- Document Media Controller concepts and workflows
+- Add pipeline visualization and debugging tools
+
+---
+
+### 10. **Performance Optimization and Zero-Copy Enhancements**
+
+**Status:** Basic zero-copy with MMAP implemented
+**Goal:** Minimize memory copies and CPU overhead for maximum throughput
+
+**Rationale:**
+Video streaming is performance-critical. Even with MMAP, the current implementation copies frames from mapped buffers. For high-resolution or high-frame-rate capture, additional optimizations are needed.
+
+**Deliverables:**
+- Implement optional zero-copy frame access with buffer lifecycle management
+- Add buffer recycling to avoid allocation overhead
+- Implement frame pool management for high-throughput scenarios
+- Optimize goroutine scheduling and channel operations
+- Add CPU usage profiling and optimization
+- Create performance testing suite with various resolutions/formats
+- Add benchmark results and optimization guide to documentation
+- Create high-throughput example (1080p60, 4K30)
+
+---
+
+### 14. **WASM Component Model Plugin System**
+
+**Status:** Not Started
+**Goal:** Enable extensible video processing pipelines using WebAssembly Component Model (WIT)
+
+**Rationale:**
+A plugin system allows users to extend go4vl with custom frame processors, filters, encoders, and analyzers without modifying the core library. Using WASM Component Model with WIT (WebAssembly Interface Types) provides:
+- Language-agnostic plugins (write in Rust, C, Go, etc.)
+- Sandboxed execution for safety and security
+- Performance approaching native code
+- Cross-platform compatibility
+- Hot-reloadable processing pipelines
+
+**Use Cases:**
+- Custom image filters and effects
+- AI/ML inference on video frames
+- Custom codec implementations
+- Specialized format converters
+- Real-time video analytics
+- Edge detection, object tracking, etc.
+
+**Deliverables:**
+- Design WIT interface definitions for video processing plugins
+- Implement WASM runtime integration (wazero or wasmtime-go)
+- Create plugin lifecycle management (load, initialize, execute, unload)
+- Add frame buffer passing between host and plugin (zero-copy where possible)
+- Implement plugin discovery and registration system
+- Create plugin development SDK and templates
+- Add example plugins in multiple languages (Rust, TinyGo, C)
+- Document plugin API and development workflow
+- Create benchmarks comparing plugin vs native performance
+- Add plugin marketplace/registry documentation
+
+**WIT Interface Design:**
+```wit
+// Example WIT interface for frame processor plugin
+interface frame-processor {
+  // Initialize plugin with configuration
+  init: func(config: string) -> result<_, string>
+
+  // Process a single frame
+  process-frame: func(input: list<u8>, width: u32, height: u32, format: u32)
+    -> result<list<u8>, string>
+
+  // Query plugin capabilities
+  get-capabilities: func() -> plugin-info
+
+  // Cleanup resources
+  cleanup: func()
+}
+```
+
+**Integration Points:**
+- Pipeline stage insertion (pre-capture, post-capture, pre-encode)
+- Format conversion plugins
+- Codec plugins for custom formats
+- Control plugins for device automation
+
+---
+
+## Additional Improvements
+
+### Documentation
+- Create comprehensive API reference with detailed examples
+- Add architecture overview and design principles document
+- Create platform-specific guides (Raspberry Pi, Jetson, x86)
+- Add troubleshooting guide for common issues
+
+### Tooling
+- Create device capability inspection CLI tool
+- Add format conversion benchmarking tool
+- Create video capture GUI example (using fyne or similar)
+- Add device stress testing utility
+
+---
+
+## Long-Term Vision
+
+- **Cross-Device Synchronization:** Support synchronized capture from multiple devices with frame alignment
+- **Cloud Integration:** Examples for streaming to cloud services (RTMP, WebRTC, HLS)
+- **AI/ML Integration:** Examples integrating with Go ML frameworks and ONNX runtime for real-time inference
+- **Embedded Optimization:** Specialized builds for resource-constrained devices with reduced memory footprint
+- **Time-Code and Genlock Support:** Professional video production features for broadcast applications
+
+---
+
+**Note:** This roadmap represents the project's aspirations and may evolve based on community contributions, user feedback, and emerging requirements.

--- a/benchmark/.gitignore
+++ b/benchmark/.gitignore
@@ -1,0 +1,1 @@
+my_results/

--- a/benchmark/BENCHMARK_SETUP.md
+++ b/benchmark/BENCHMARK_SETUP.md
@@ -1,0 +1,248 @@
+# Benchmark Setup Guide
+
+This guide explains how to set up reproducible benchmarking using v4l2loopback and ffmpeg.
+
+## Why Use v4l2loopback?
+
+Using a virtual test device provides:
+
+- **Reproducible results**: Same test pattern every time
+- **No hardware dependency**: Works in CI/CD
+- **Controlled conditions**: Known resolution, FPS, format
+- **No camera quirks**: Eliminates hardware variability
+
+## Prerequisites
+
+### Install Dependencies
+
+```bash
+# Ubuntu/Debian
+sudo apt install v4l2loopback-dkms ffmpeg v4l-utils
+
+# Arch
+sudo pacman -S v4l2loopback-dkms ffmpeg v4l-utils
+
+# Fedora
+sudo dnf install v4l2loopback ffmpeg v4l-utils
+```
+
+### Verify Installation
+
+```bash
+# Check if v4l2loopback module is available
+modinfo v4l2loopback
+
+# Check ffmpeg
+ffmpeg -version
+
+# Check v4l-utils
+v4l2-ctl --version
+```
+
+## Quick Start
+
+### Option 1: Automatic Setup (Recommended)
+
+Run the setup script that handles everything:
+
+```bash
+cd benchmark
+sudo go run setup_loopback.go
+```
+
+This will:
+1. Load v4l2loopback module
+2. Create `/dev/video50`
+3. Start ffmpeg test pattern
+4. Keep running until you press Ctrl+C
+
+Then in another terminal, run benchmarks:
+
+```bash
+cd benchmark/frame_capture
+go run main.go -device /dev/video50
+```
+
+### Option 2: Manual Setup
+
+```bash
+# Load module
+sudo modprobe v4l2loopback devices=1 video_nr=50 card_label=benchmark exclusive_caps=1
+
+# Start test pattern
+ffmpeg -re -f lavfi -i testsrc=size=640x480:rate=30 -pix_fmt yuyv422 -f v4l2 /dev/video50 &
+
+# Run benchmark
+cd benchmark/frame_capture
+go run main.go -device /dev/video50
+
+# Cleanup
+killall ffmpeg
+sudo modprobe -r v4l2loopback
+```
+
+### Option 3: Use Existing Camera
+
+If you have a physical webcam:
+
+```bash
+# Find your device
+ls -l /dev/video*
+v4l2-ctl --list-devices
+
+# Run benchmark directly
+cd benchmark/frame_capture
+go run main.go -device /dev/video0
+```
+
+## Setup Script Options
+
+The `setup_loopback.go` script accepts flags:
+
+```bash
+# Different device number
+sudo go run setup_loopback.go -device 40
+
+# Different resolution and FPS
+sudo go run setup_loopback.go -width 1920 -height 1080 -fps 60
+
+# Different test pattern
+sudo go run setup_loopback.go -pattern smptebars  # Color bars
+sudo go run setup_loopback.go -pattern color      # Solid color
+sudo go run setup_loopback.go -pattern testsrc    # Default test pattern
+```
+
+## Test Patterns Available
+
+- **testsrc**: Standard test pattern with moving elements
+- **smptebars**: SMPTE color bars
+- **color**: Solid color (configurable)
+- **mandelbrot**: Animated Mandelbrot set
+- **life**: Conway's Game of Life
+
+## Troubleshooting
+
+### Module Not Found
+
+```bash
+# Install v4l2loopback
+sudo apt install v4l2loopback-dkms
+
+# Rebuild module for current kernel
+sudo dkms install v4l2loopback/$(modinfo v4l2loopback | grep ^version | awk '{print $2}')
+```
+
+### Device Already Exists
+
+```bash
+# Unload existing module
+sudo modprobe -r v4l2loopback
+
+# Re-run setup
+sudo go run setup_loopback.go
+```
+
+### Permission Denied
+
+```bash
+# Add user to video group
+sudo usermod -a -G video $USER
+# Log out and back in
+
+# Or temporarily
+sudo chmod 666 /dev/video50
+```
+
+### FFmpeg Errors
+
+```bash
+# Check if device is accessible
+v4l2-ctl -d /dev/video50 --all
+
+# Check ffmpeg can write to it
+ffmpeg -f lavfi -i testsrc=size=640x480:rate=1 -vframes 1 -f v4l2 /dev/video50
+```
+
+## CI/CD Integration
+
+For automated testing in CI/CD:
+
+```yaml
+# GitHub Actions example
+- name: Setup v4l2loopback
+  run: |
+    sudo apt-get update
+    sudo apt-get install -y v4l2loopback-dkms ffmpeg
+    sudo modprobe v4l2loopback devices=1 video_nr=50 exclusive_caps=1
+
+- name: Start test pattern
+  run: |
+    ffmpeg -re -f lavfi -i testsrc=size=640x480:rate=30 \
+           -pix_fmt yuyv422 -f v4l2 /dev/video50 &
+    sleep 2
+
+- name: Run benchmarks
+  run: |
+    cd benchmark/frame_capture
+    go run main.go -device /dev/video50 -duration 5s
+```
+
+## Multiple Test Devices
+
+To create multiple devices for testing:
+
+```bash
+# Load with multiple devices
+sudo modprobe v4l2loopback devices=2 video_nr=50,51 card_label=bench1,bench2 exclusive_caps=1
+
+# Start patterns on both
+ffmpeg -re -f lavfi -i testsrc=size=640x480:rate=30 -pix_fmt yuyv422 -f v4l2 /dev/video50 &
+ffmpeg -re -f lavfi -i smptebars=size=1280x720:rate=30 -pix_fmt yuyv422 -f v4l2 /dev/video51 &
+```
+
+## Benchmarking Best Practices
+
+1. **Use v4l2loopback for baseline measurements**
+   - Eliminates hardware variability
+   - Reproducible results
+
+2. **Test with real hardware for final validation**
+   - Verify real-world performance
+   - Check device-specific optimizations
+
+3. **Run benchmarks multiple times**
+   - Average results across runs
+   - Look for consistency
+
+4. **Use consistent test patterns**
+   - Same resolution and FPS
+   - Same pixel format
+
+5. **Monitor system load**
+   - Run benchmarks on idle system
+   - Check for background processes
+
+## Next Steps
+
+Once your test device is set up:
+
+1. Run baseline benchmarks (see `frame_capture/README.md`)
+2. Analyze profiles with pprof (see main `README.md`)
+3. Implement optimizations
+4. Re-run benchmarks to measure improvement
+
+## Cleanup
+
+Always cleanup when done:
+
+```bash
+# Stop ffmpeg
+killall ffmpeg
+
+# Unload module
+sudo modprobe -r v4l2loopback
+
+# Verify
+lsmod | grep v4l2loopback  # Should be empty
+ls /dev/video50  # Should not exist
+```

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,387 @@
+# go4vl Benchmarking Suite
+
+Performance profiling and benchmarking tools for testing the **actual go4vl code** (device package, v4l2 package, buffer management, frame copying).
+
+## Quick Start
+
+### Loopback Mode (Default)
+
+Automatically sets up v4l2loopback device and benchmarks real go4vl code:
+
+```bash
+cd runner
+sudo go run main.go -single -duration 5s
+```
+
+### Physical Device Mode
+
+Test with your actual webcam:
+
+```bash
+cd runner
+go run main.go -single -device /dev/video0 -duration 5s
+```
+
+## What It Tests
+
+The benchmark exercises **real go4vl code paths**:
+
+1. **device.Open()** - Device initialization and configuration
+2. **v4l2.InitBuffers()** - Buffer allocation
+3. **v4l2.MapMemoryBuffers()** - Memory mapping (zero-copy)
+4. **v4l2.QueueBuffer() / DequeueBuffer()** - Buffer queue/dequeue operations
+5. **Frame copying** - Memory allocation and copying from mapped buffers
+6. **Channel operations** - Frame delivery via Go channels
+7. **Context handling** - Timeout and cancellation
+
+This is **not a synthetic benchmark** - it runs the actual V4L2 syscalls and measures real performance.
+
+## Structure
+
+```
+benchmark/
+├── loopback/
+│   └── main.go      # v4l2loopback device setup utility
+└── runner/
+    └── main.go      # Benchmark runner
+```
+
+## Usage
+
+### Single Benchmark
+
+Run one benchmark with custom parameters:
+
+```bash
+sudo go run main.go -single [flags]
+```
+
+**Flags:**
+- `-single` - Run single benchmark (vs multi-scenario)
+- `-duration` - Capture duration (default: 10s)
+- `-width` - Frame width (default: 640)
+- `-height` - Frame height (default: 480)
+- `-fps` - Frames per second (default: 30)
+- `-format` - Pixel format: MJPEG, YUYV, H264 (default: MJPEG)
+- `-buffers` - Number of buffers (default: 4)
+- `-verbose` - Verbose output
+
+**Device Selection:**
+- **Default**: Sets up loopback device (requires sudo, ffmpeg, v4l2loopback-dkms)
+- `-device /dev/videoN` - Use real device instead
+- `-loopback-num N` - Loopback device number (default: 50)
+- `-test-pattern` - FFmpeg pattern: testsrc, smptebars, color=<color>
+
+**Profiling:**
+- `-cpuprofile <file>` - Write CPU profile
+- `-memprofile <file>` - Write memory profile
+- `-trace <file>` - Write execution trace
+
+### Multi-Scenario Benchmarks
+
+Run all predefined scenarios:
+
+```bash
+sudo go run main.go [flags]
+```
+
+**Flags:**
+- `-duration` - Duration per scenario (default: 10s)
+- `-output` - Output directory (default: results_<timestamp>)
+- `-scenario` - Run specific scenario by name
+- `-list` - List available scenarios
+- `-device /dev/videoN` - Use real device instead of loopback
+
+## Examples
+
+### Quick 5 Second Test
+
+```bash
+sudo go run main.go -single -duration 5s
+```
+
+### Loopback with Different Test Patterns
+
+```bash
+# Default test pattern
+sudo go run main.go -single -duration 10s
+
+# SMPTE color bars
+sudo go run main.go -single -test-pattern smptebars
+
+# Solid red
+sudo go run main.go -single -test-pattern color=red
+```
+
+### 1080p Performance Test
+
+```bash
+sudo go run main.go -single \
+  -width 1920 -height 1080 -fps 60 \
+  -duration 30s
+```
+
+### Test Physical Webcam
+
+```bash
+# Usually /dev/video0
+go run main.go -single -device /dev/video0 -duration 10s
+
+# Specific device
+go run main.go -single -device /dev/video2 -duration 10s
+```
+
+### Full Profiling Session
+
+```bash
+sudo go run main.go -single \
+  -duration 30s \
+  -cpuprofile cpu.prof \
+  -memprofile mem.prof \
+  -trace trace.out
+
+# Analyze
+go tool pprof cpu.prof
+go tool pprof mem.prof
+go tool trace trace.out
+```
+
+### Run All Scenarios
+
+```bash
+# With loopback (default)
+sudo go run main.go -duration 15s -output baseline_results
+
+# With real device
+go run main.go -device /dev/video0 -duration 15s -output webcam_results
+```
+
+### Run Specific Scenario
+
+```bash
+sudo go run main.go -scenario baseline_720p_mjpeg
+```
+
+## Available Scenarios
+
+```bash
+$ go run main.go -list
+Available benchmark scenarios:
+  baseline_480p_mjpeg: 640x480 @ 30 fps (MJPEG)
+  baseline_720p_mjpeg: 1280x720 @ 30 fps (MJPEG)
+  baseline_1080p_mjpeg: 1920x1080 @ 30 fps (MJPEG)
+  format_480p_yuyv: 640x480 @ 30 fps (YUYV)
+  fps_720p_15fps: 1280x720 @ 15 fps (MJPEG)
+  fps_720p_30fps: 1280x720 @ 30 fps (MJPEG)
+  fps_720p_60fps: 1280x720 @ 60 fps (MJPEG)
+```
+
+## Key Metrics
+
+### Capture Statistics
+- **Frames Captured/Dropped** - Reliability indicator
+- **Average FPS** - Should match target FPS
+- **Frame Timing** - Min/Max/Avg frame time consistency
+
+### Memory Statistics
+- **Allocs per Frame** - Lower is better (target < 100KB)
+- **GC Frequency** - Fewer GC runs = smoother performance
+- **Total Allocations** - Memory churn indicator
+
+### Performance Indicators
+- **CPU Time per Frame** - Processing efficiency
+- **Throughput (MB/s)** - Data handling capacity
+- **GC Pause Times** - Latency impact
+
+## Performance Goals
+
+| Resolution | FPS | CPU Usage | Memory/Frame | Frame Drops |
+|------------|-----|-----------|--------------|-------------|
+| 640x480    | 30  | < 5%      | < 100KB      | 0           |
+| 1280x720   | 30  | < 10%     | < 150KB      | 0           |
+| 1920x1080  | 30  | < 20%     | < 200KB      | 0           |
+| 1920x1080  | 60  | < 35%     | < 200KB      | < 1%        |
+
+## How It Works
+
+### Loopback Mode (Default)
+1. **Checks prerequisites** - Verifies ffmpeg and v4l2loopback-dkms installed
+2. **Loads v4l2loopback** - Creates /dev/video50 (or specified device number)
+3. **Starts FFmpeg** - Generates test pattern at specified resolution/FPS
+4. **Runs benchmark** - Captures frames via **actual V4L2 API** and go4vl code
+5. **Cleans up** - Stops FFmpeg and unloads v4l2loopback module
+
+### Device Mode
+1. **Opens device** - Connects to specified video device via **device.Open()**
+2. **Configures format** - Sets resolution, FPS, pixel format via **v4l2** package
+3. **Maps buffers** - Memory maps buffers via **v4l2.MapMemoryBuffers()**
+4. **Captures frames** - Reads from device via **v4l2.DequeueBuffer()**
+5. **Copies frames** - Allocates and copies data via **device package**
+6. **Metrics collection** - Tracks performance and memory of actual code
+
+## Prerequisites
+
+### Loopback Mode (Default)
+
+#### Ubuntu/Debian
+```bash
+sudo apt install ffmpeg v4l2loopback-dkms
+sudo dkms autoinstall
+```
+
+#### Arch Linux
+```bash
+sudo pacman -S ffmpeg v4l2loopback-dkms
+```
+
+#### Fedora
+```bash
+sudo dnf install ffmpeg v4l2loopback
+```
+
+### Device Mode
+No installation needed - just requires a working /dev/videoN device
+
+## Troubleshooting
+
+### Loopback Mode Issues
+
+#### Module Not Found Error
+```
+ERROR: v4l2loopback kernel module not installed
+```
+
+**Solution**: Install v4l2loopback-dkms and rebuild:
+```bash
+sudo apt install v4l2loopback-dkms
+sudo dkms autoinstall
+```
+
+#### FFmpeg Not Found
+```
+ERROR: ffmpeg not found
+```
+
+**Solution**:
+```bash
+sudo apt install ffmpeg
+```
+
+#### Permission Denied
+Loopback mode requires `sudo` to load/unload kernel modules:
+```bash
+sudo go run main.go -single
+```
+
+#### Device Already Exists
+If `/dev/video50` already exists from a previous run:
+
+```bash
+# Clean up manually
+sudo modprobe -r v4l2loopback
+```
+
+Or use a different device number:
+```bash
+sudo go run main.go -single -loopback-num 51
+```
+
+### Device Mode Issues
+
+#### No Device Found
+```bash
+# List available devices
+ls -l /dev/video*
+
+# Check device capabilities
+v4l2-ctl --list-devices
+```
+
+#### Permission Denied
+Add your user to the `video` group:
+```bash
+sudo usermod -a -G video $USER
+# Log out and back in
+```
+
+### General
+
+#### Interrupt Handling
+Press `Ctrl+C` to cleanly stop benchmarks. The program automatically:
+- Stops FFmpeg (loopback mode)
+- Unloads v4l2loopback (loopback mode)
+- Closes device connections
+- Cleans up resources
+
+## Analyzing Results
+
+### Multi-Scenario Output
+
+```bash
+cd results_<timestamp>/
+
+# View all results
+cat summary.txt
+
+# Individual results
+cat baseline_480p_mjpeg_results.txt
+
+# Analyze profiles
+go tool pprof baseline_480p_mjpeg_cpu.prof
+go tool pprof baseline_480p_mjpeg_mem.prof
+go tool trace baseline_480p_mjpeg_trace.out
+```
+
+### Using pprof
+
+```bash
+# Interactive mode
+go tool pprof cpu.prof
+> top10         # Top 10 CPU consumers
+> list main.*   # Annotated source
+> web           # Visual graph (requires graphviz)
+
+# Web UI
+go tool pprof -http=:8080 cpu.prof
+```
+
+### Using trace
+
+```bash
+go tool trace trace.out
+```
+
+Opens browser showing:
+- Goroutine execution timeline
+- GC events and pauses
+- System calls and blocking
+- Goroutine analysis
+
+## Comparison Workflows
+
+### Before/After Optimization
+
+```bash
+# Baseline
+sudo go run main.go -output before_opt
+
+# Make code changes...
+
+# After optimization
+sudo go run main.go -output after_opt
+
+# Compare
+diff before_opt/summary.txt after_opt/summary.txt
+```
+
+### Resolution Comparison
+
+```bash
+sudo go run main.go -single -width 640 -height 480 -output 480p
+sudo go run main.go -single -width 1280 -height 720 -output 720p
+sudo go run main.go -single -width 1920 -height 1080 -output 1080p
+```
+
+## Next Steps
+
+See `/docs/performance-optimization-plan.md` for the complete optimization roadmap and implementation strategy.

--- a/benchmark/loopback/example_test.go
+++ b/benchmark/loopback/example_test.go
@@ -1,0 +1,67 @@
+package loopback_test
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/vladimirvivien/go4vl/benchmark/loopback"
+)
+
+// Example demonstrates how to setup and use a v4l2loopback device
+func Example() {
+	// Check if loopback is available
+	if !loopback.IsAvailable() {
+		log.Println("Loopback not available: install ffmpeg and v4l2loopback-dkms")
+		return
+	}
+
+	// Setup loopback device: /dev/video50 at 640x480@30fps with test pattern
+	dev, err := loopback.Setup(50, 640, 480, 30, "testsrc")
+	if err != nil {
+		log.Fatalf("Failed to setup loopback: %v", err)
+	}
+	defer dev.Close()
+
+	fmt.Printf("Loopback device ready at %s\n", dev.DevicePath)
+
+	// Device is now ready to use with go4vl or other V4L2 applications
+	time.Sleep(5 * time.Second)
+
+	// Cleanup happens automatically via defer
+	fmt.Println("Cleaning up...")
+}
+
+// Example_customPattern shows how to use different test patterns
+func Example_customPattern() {
+	if !loopback.IsAvailable() {
+		return
+	}
+
+	// SMPTE color bars
+	dev, err := loopback.Setup(50, 1280, 720, 30, "smptebars")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer dev.Close()
+
+	fmt.Println("SMPTE color bars streaming...")
+	time.Sleep(2 * time.Second)
+}
+
+// Example_solidColor shows how to stream a solid color
+func Example_solidColor() {
+	if !loopback.IsAvailable() {
+		return
+	}
+
+	// Solid red color
+	dev, err := loopback.Setup(50, 640, 480, 30, "color=red")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer dev.Close()
+
+	fmt.Println("Red screen streaming...")
+	time.Sleep(2 * time.Second)
+}

--- a/benchmark/loopback/main.go
+++ b/benchmark/loopback/main.go
@@ -1,0 +1,152 @@
+package loopback
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// Device represents a v4l2loopback virtual device
+type Device struct {
+	DevicePath string
+	DeviceNum  int
+	FFmpegCmd  *exec.Cmd
+}
+
+// Setup creates a v4l2loopback device and starts ffmpeg feeding it
+func Setup(deviceNum int, width, height, fps int, testPattern string) (*Device, error) {
+	dev := &Device{
+		DevicePath: fmt.Sprintf("/dev/video%d", deviceNum),
+		DeviceNum:  deviceNum,
+	}
+
+	// Check if device already exists
+	if _, err := os.Stat(dev.DevicePath); err == nil {
+		return nil, fmt.Errorf("device %s already exists, unload v4l2loopback first", dev.DevicePath)
+	}
+
+	// Check prerequisites
+	if err := checkPrerequisites(); err != nil {
+		return nil, err
+	}
+
+	// Load v4l2loopback module
+	if err := loadModule(deviceNum); err != nil {
+		return nil, fmt.Errorf("failed to load v4l2loopback: %w", err)
+	}
+
+	// Wait for device to appear
+	time.Sleep(500 * time.Millisecond)
+
+	// Verify device exists
+	if _, err := os.Stat(dev.DevicePath); err != nil {
+		unloadModule()
+		return nil, fmt.Errorf("device %s not created after loading module", dev.DevicePath)
+	}
+
+	// Start ffmpeg
+	if err := dev.startFFmpeg(width, height, fps, testPattern); err != nil {
+		unloadModule()
+		return nil, fmt.Errorf("failed to start ffmpeg: %w", err)
+	}
+
+	// Wait for ffmpeg to initialize
+	time.Sleep(1 * time.Second)
+
+	return dev, nil
+}
+
+// Close stops ffmpeg and unloads the v4l2loopback module
+func (d *Device) Close() error {
+	// Stop ffmpeg
+	if d.FFmpegCmd != nil && d.FFmpegCmd.Process != nil {
+		d.FFmpegCmd.Process.Kill()
+		d.FFmpegCmd.Wait()
+	}
+
+	// Unload module
+	return unloadModule()
+}
+
+// checkPrerequisites verifies ffmpeg and v4l2loopback are available
+func checkPrerequisites() error {
+	// Check ffmpeg
+	if _, err := exec.LookPath("ffmpeg"); err != nil {
+		return fmt.Errorf("ffmpeg not found: install with 'sudo apt install ffmpeg'")
+	}
+
+	// Check v4l2loopback module
+	cmd := exec.Command("modinfo", "v4l2loopback")
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("v4l2loopback kernel module not installed: install with 'sudo apt install v4l2loopback-dkms'")
+	}
+
+	return nil
+}
+
+// loadModule loads the v4l2loopback kernel module
+func loadModule(deviceNum int) error {
+	cmd := exec.Command("modprobe", "v4l2loopback",
+		fmt.Sprintf("video_nr=%d", deviceNum),
+		"card_label=go4vl_benchmark",
+		"exclusive_caps=1")
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%w: %s", err, string(output))
+	}
+
+	return nil
+}
+
+// unloadModule unloads the v4l2loopback kernel module
+func unloadModule() error {
+	cmd := exec.Command("modprobe", "-r", "v4l2loopback")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%w: %s", err, string(output))
+	}
+	return nil
+}
+
+// startFFmpeg starts ffmpeg to feed the loopback device
+func (d *Device) startFFmpeg(width, height, fps int, testPattern string) error {
+	// Parse test pattern (e.g., "testsrc", "smptebars", "color=red")
+	var source string
+	if strings.HasPrefix(testPattern, "color=") {
+		color := strings.TrimPrefix(testPattern, "color=")
+		source = fmt.Sprintf("color=c=%s:s=%dx%d:r=%d", color, width, height, fps)
+	} else if testPattern == "" || testPattern == "testsrc" {
+		source = fmt.Sprintf("testsrc=size=%dx%d:rate=%d", width, height, fps)
+	} else {
+		source = fmt.Sprintf("%s=size=%dx%d:rate=%d", testPattern, width, height, fps)
+	}
+
+	args := []string{
+		"-re",
+		"-f", "lavfi",
+		"-i", source,
+		"-pix_fmt", "yuyv422",
+		"-f", "v4l2",
+		d.DevicePath,
+	}
+
+	d.FFmpegCmd = exec.Command("ffmpeg", args...)
+
+	// Suppress ffmpeg output
+	d.FFmpegCmd.Stdout = nil
+	d.FFmpegCmd.Stderr = nil
+
+	if err := d.FFmpegCmd.Start(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// IsAvailable checks if v4l2loopback and ffmpeg are installed
+func IsAvailable() bool {
+	return checkPrerequisites() == nil
+}

--- a/benchmark/runner/README.md
+++ b/benchmark/runner/README.md
@@ -1,0 +1,166 @@
+# Benchmark Runner
+
+A Go-based benchmark orchestration tool using [gexe](https://github.com/vladimirvivien/gexe) to automate running performance benchmarks.
+
+## Features
+
+- Runs multiple benchmark scenarios automatically
+- Builds benchmark program on-the-fly
+- Generates CPU, memory profiles, and execution traces
+- Creates summary report
+- Pure Go implementation (no shell scripts)
+
+## Usage
+
+### Run All Benchmarks
+
+```bash
+cd benchmark/runner
+go run main.go
+```
+
+### Run Specific Device
+
+```bash
+go run main.go -device /dev/video1
+```
+
+### Run Single Scenario
+
+```bash
+# List available scenarios
+go run main.go -list
+
+# Run specific scenario
+go run main.go -scenario baseline_720p_mjpeg
+```
+
+### Custom Duration and Output
+
+```bash
+go run main.go -duration 30s -output my_results
+```
+
+## Command-Line Flags
+
+- `-device string`: Video device path (default: /dev/video0)
+- `-duration string`: Capture duration per benchmark (default: 10s)
+- `-output string`: Output directory (default: results_<timestamp>)
+- `-scenario string`: Run specific scenario by name (empty = run all)
+- `-list`: List available scenarios and exit
+
+## Available Scenarios
+
+The runner includes predefined benchmark scenarios:
+
+**Baseline Benchmarks:**
+- `baseline_480p_mjpeg`: 640x480 @ 30fps MJPEG
+- `baseline_720p_mjpeg`: 1280x720 @ 30fps MJPEG
+- `baseline_1080p_mjpeg`: 1920x1080 @ 30fps MJPEG
+
+**Format Comparison:**
+- `format_480p_yuyv`: 640x480 @ 30fps YUYV (raw)
+
+**Frame Rate Tests:**
+- `fps_720p_15fps`: 1280x720 @ 15fps MJPEG
+- `fps_720p_30fps`: 1280x720 @ 30fps MJPEG
+- `fps_720p_60fps`: 1280x720 @ 60fps MJPEG
+
+## Output Files
+
+For each scenario, the runner generates:
+
+- `<scenario>_results.txt`: Benchmark output with statistics
+- `<scenario>_cpu.prof`: CPU profile for pprof analysis
+- `<scenario>_mem.prof`: Memory profile for pprof analysis
+- `<scenario>_trace.out`: Execution trace for trace viewer
+- `summary.txt`: Combined results from all scenarios
+
+## Examples
+
+### Quick Baseline Check
+
+```bash
+# Run just 480p baseline for quick validation
+go run main.go -scenario baseline_480p_mjpeg -duration 5s
+```
+
+### Full Performance Suite
+
+```bash
+# Run all scenarios with longer duration
+go run main.go -duration 30s -output full_benchmark
+```
+
+### Compare Before/After Optimization
+
+```bash
+# Baseline
+go run main.go -output before_optimization
+
+# ... make code changes ...
+
+# After optimization
+go run main.go -output after_optimization
+
+# Compare results
+diff before_optimization/summary.txt after_optimization/summary.txt
+```
+
+## Adding Custom Scenarios
+
+Edit `main.go` and add to the `scenarios` slice:
+
+```go
+var scenarios = []BenchmarkScenario{
+    // ... existing scenarios ...
+    {Name: "custom_4k_test", Width: 3840, Height: 2160, FPS: 30, Format: "MJPEG"},
+}
+```
+
+## Integration with CI/CD
+
+The runner can be used in automated testing:
+
+```bash
+# Run benchmarks and check for regressions
+go run main.go -duration 10s
+if [ $? -eq 0 ]; then
+    echo "Benchmarks passed"
+else
+    echo "Benchmarks failed"
+    exit 1
+fi
+```
+
+## Troubleshooting
+
+### Device Not Found
+
+```bash
+# Check available devices
+ls -l /dev/video*
+
+# Specify correct device
+go run main.go -device /dev/video1
+```
+
+### Build Errors
+
+```bash
+# Ensure dependencies are installed
+cd ../frame_capture
+go mod tidy
+go build
+```
+
+### Permission Denied
+
+```bash
+# Add user to video group
+sudo usermod -a -G video $USER
+# Log out and back in
+
+# Or run with sudo (not recommended)
+sudo go run main.go
+```

--- a/benchmark/runner/main.go
+++ b/benchmark/runner/main.go
@@ -1,0 +1,620 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/pprof"
+	"runtime/trace"
+	"strings"
+	"time"
+
+	"github.com/vladimirvivien/go4vl/benchmark/loopback"
+	"github.com/vladimirvivien/go4vl/device"
+	"github.com/vladimirvivien/go4vl/v4l2"
+)
+
+type BenchmarkScenario struct {
+	Name   string
+	Width  int
+	Height int
+	FPS    int
+	Format string
+}
+
+type BenchmarkConfig struct {
+	DevicePath  string
+	Width       uint32
+	Height      uint32
+	PixelFormat uint32
+	FPS         uint32
+	Duration    time.Duration
+	BufferSize  uint32
+	CPUProfile  string
+	MemProfile  string
+	TraceFile   string
+	Verbose     bool
+}
+
+type BenchmarkResults struct {
+	FramesCaptured   int
+	FramesDropped    int
+	Duration         time.Duration
+	AvgFPS           float64
+	MinFrameTime     time.Duration
+	MaxFrameTime     time.Duration
+	AvgFrameTime     time.Duration
+	TotalBytes       uint64
+	AvgBytesPerFrame uint64
+	MemAllocBytes    uint64
+	MemAllocObjects  uint64
+	NumGC            uint32
+	GCPauseTotal     time.Duration
+}
+
+var scenarios = []BenchmarkScenario{
+	// Baseline benchmarks
+	{Name: "baseline_480p_mjpeg", Width: 640, Height: 480, FPS: 30, Format: "MJPEG"},
+	{Name: "baseline_720p_mjpeg", Width: 1280, Height: 720, FPS: 30, Format: "MJPEG"},
+	{Name: "baseline_1080p_mjpeg", Width: 1920, Height: 1080, FPS: 30, Format: "MJPEG"},
+
+	// Format comparison (at 480p)
+	{Name: "format_480p_yuyv", Width: 640, Height: 480, FPS: 30, Format: "YUYV"},
+
+	// Frame rate tests (at 720p)
+	{Name: "fps_720p_15fps", Width: 1280, Height: 720, FPS: 15, Format: "MJPEG"},
+	{Name: "fps_720p_30fps", Width: 1280, Height: 720, FPS: 30, Format: "MJPEG"},
+	{Name: "fps_720p_60fps", Width: 1280, Height: 720, FPS: 60, Format: "MJPEG"},
+}
+
+func main() {
+	// Mode selection (mutually exclusive)
+	device := flag.String("device", "", "Use real device at path (e.g., /dev/video0)")
+
+	// Loopback device parameters (default mode if -device not specified)
+	loopbackNum := flag.Int("loopback-num", 50, "Loopback device number (default mode)")
+	testPattern := flag.String("test-pattern", "testsrc", "FFmpeg test pattern: testsrc, smptebars, color=<color>")
+
+	// Benchmark parameters
+	duration := flag.String("duration", "10s", "Capture duration per benchmark")
+	outputDir := flag.String("output", "", "Output directory (default: results_<timestamp>)")
+	scenario := flag.String("scenario", "", "Run specific scenario by name (empty = run all)")
+	list := flag.Bool("list", false, "List available scenarios and exit")
+	single := flag.Bool("single", false, "Run single benchmark with custom parameters")
+
+	// Single benchmark parameters
+	width := flag.Uint("width", 640, "Frame width")
+	height := flag.Uint("height", 480, "Frame height")
+	fps := flag.Uint("fps", 30, "Frames per second")
+	format := flag.String("format", "MJPEG", "Pixel format: MJPEG, YUYV, H264")
+	buffers := flag.Uint("buffers", 4, "Number of buffers")
+	verbose := flag.Bool("verbose", false, "Verbose output")
+	cpuprofile := flag.String("cpuprofile", "", "Write CPU profile to file")
+	memprofile := flag.String("memprofile", "", "Write memory profile to file")
+	tracefile := flag.String("trace", "", "Write execution trace to file")
+
+	flag.Parse()
+
+	// List scenarios if requested
+	if *list {
+		fmt.Println("Available benchmark scenarios:")
+		for _, s := range scenarios {
+			fmt.Printf("  %s: %dx%d @ %d fps (%s)\n", s.Name, s.Width, s.Height, s.FPS, s.Format)
+		}
+		return
+	}
+
+	// Determine device path: use real device if specified, otherwise setup loopback
+	var devicePath string
+	var loopbackDev *loopback.Device
+
+	if *device != "" {
+		// User specified a real device
+		devicePath = *device
+		log.Printf("Using real device: %s", devicePath)
+	} else {
+		// Default: setup loopback device
+		if !loopback.IsAvailable() {
+			log.Fatal("Loopback mode requires ffmpeg and v4l2loopback-dkms to be installed.\nInstall with: sudo apt install ffmpeg v4l2loopback-dkms")
+		}
+
+		log.Printf("Setting up loopback device /dev/video%d...", *loopbackNum)
+		var err error
+		loopbackDev, err = loopback.Setup(*loopbackNum, int(*width), int(*height), int(*fps), *testPattern)
+		if err != nil {
+			log.Fatalf("Failed to setup loopback device: %v", err)
+		}
+		defer loopbackDev.Close()
+
+		devicePath = loopbackDev.DevicePath
+		log.Printf("Loopback device ready at %s", devicePath)
+	}
+
+	// Single benchmark mode
+	if *single {
+		config := BenchmarkConfig{
+			DevicePath: devicePath,
+			Width:      uint32(*width),
+			Height:     uint32(*height),
+			FPS:        uint32(*fps),
+			Duration:   parseDuration(*duration),
+			BufferSize: uint32(*buffers),
+			CPUProfile: *cpuprofile,
+			MemProfile: *memprofile,
+			TraceFile:  *tracefile,
+			Verbose:    *verbose,
+		}
+
+		// Map format string
+		switch *format {
+		case "MJPEG":
+			config.PixelFormat = v4l2.PixelFmtMJPEG
+		case "YUYV":
+			config.PixelFormat = v4l2.PixelFmtYUYV
+		case "H264":
+			config.PixelFormat = v4l2.PixelFmtH264
+		default:
+			log.Fatalf("Unknown pixel format: %s", *format)
+		}
+
+		runSingleBenchmark(config)
+		return
+	}
+
+	// Multi-scenario benchmark mode
+	runMultiScenario(devicePath, *duration, *outputDir, *scenario)
+}
+
+func runSingleBenchmark(config BenchmarkConfig) {
+	// Start profiling if requested
+	if config.CPUProfile != "" {
+		f, err := os.Create(config.CPUProfile)
+		if err != nil {
+			log.Fatalf("Could not create CPU profile: %v", err)
+		}
+		defer f.Close()
+		if err := pprof.StartCPUProfile(f); err != nil {
+			log.Fatalf("Could not start CPU profile: %v", err)
+		}
+		defer pprof.StopCPUProfile()
+		log.Printf("CPU profiling enabled: %s", config.CPUProfile)
+	}
+
+	if config.TraceFile != "" {
+		f, err := os.Create(config.TraceFile)
+		if err != nil {
+			log.Fatalf("Could not create trace file: %v", err)
+		}
+		defer f.Close()
+		if err := trace.Start(f); err != nil {
+			log.Fatalf("Could not start trace: %v", err)
+		}
+		defer trace.Stop()
+		log.Printf("Execution trace enabled: %s", config.TraceFile)
+	}
+
+	// Run benchmark
+	results := runDeviceBenchmark(config)
+
+	// Write memory profile if requested
+	if config.MemProfile != "" {
+		f, err := os.Create(config.MemProfile)
+		if err != nil {
+			log.Fatalf("Could not create memory profile: %v", err)
+		}
+		defer f.Close()
+		runtime.GC() // Force GC before taking heap snapshot
+		if err := pprof.WriteHeapProfile(f); err != nil {
+			log.Fatalf("Could not write memory profile: %v", err)
+		}
+		log.Printf("Memory profile written: %s", config.MemProfile)
+	}
+
+	// Print results
+	printResults(config, results)
+}
+
+func runMultiScenario(devicePath, duration, outputDir, scenarioName string) {
+	// Create output directory
+	if outputDir == "" {
+		outputDir = fmt.Sprintf("results_%s", time.Now().Format("20060102_150405"))
+	}
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		log.Fatalf("Failed to create output directory: %v", err)
+	}
+
+	fmt.Println("========================================")
+	fmt.Println("go4vl Frame Capture Benchmark Suite")
+	fmt.Println("========================================")
+	fmt.Printf("Device:   %s\n", devicePath)
+	fmt.Printf("Duration: %s\n", duration)
+	fmt.Printf("Output:   %s\n", outputDir)
+	fmt.Println()
+
+	// Filter scenarios if specific one requested
+	var toRun []BenchmarkScenario
+	if scenarioName != "" {
+		found := false
+		for _, s := range scenarios {
+			if s.Name == scenarioName {
+				toRun = []BenchmarkScenario{s}
+				found = true
+				break
+			}
+		}
+		if !found {
+			log.Fatalf("Unknown scenario: %s (use -list to see available scenarios)", scenarioName)
+		}
+	} else {
+		toRun = scenarios
+	}
+
+	// Run benchmarks
+	results := make(map[string]string)
+	for i, s := range toRun {
+		fmt.Printf("[%d/%d] Running: %s (%dx%d @ %d fps, %s)\n",
+			i+1, len(toRun), s.Name, s.Width, s.Height, s.FPS, s.Format)
+
+		resultFile := filepath.Join(outputDir, fmt.Sprintf("%s_results.txt", s.Name))
+		cpuProfile := filepath.Join(outputDir, fmt.Sprintf("%s_cpu.prof", s.Name))
+		memProfile := filepath.Join(outputDir, fmt.Sprintf("%s_mem.prof", s.Name))
+		traceFile := filepath.Join(outputDir, fmt.Sprintf("%s_trace.out", s.Name))
+
+		// Parse format
+		var pixelFormat uint32
+		switch s.Format {
+		case "MJPEG":
+			pixelFormat = v4l2.PixelFmtMJPEG
+		case "YUYV":
+			pixelFormat = v4l2.PixelFmtYUYV
+		case "H264":
+			pixelFormat = v4l2.PixelFmtH264
+		default:
+			log.Printf("Warning: Unknown format %s, skipping", s.Format)
+			results[s.Name] = "SKIPPED"
+			continue
+		}
+
+		config := BenchmarkConfig{
+			DevicePath:  devicePath,
+			Width:       uint32(s.Width),
+			Height:      uint32(s.Height),
+			FPS:         uint32(s.FPS),
+			PixelFormat: pixelFormat,
+			Duration:    parseDuration(duration),
+			BufferSize:  4,
+			CPUProfile:  cpuProfile,
+			MemProfile:  memProfile,
+			TraceFile:   traceFile,
+			Verbose:     false,
+		}
+
+		// Capture output to buffer
+		var buf bytes.Buffer
+		oldStdout := os.Stdout
+		oldStderr := os.Stderr
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+		os.Stderr = w
+
+		// Run in goroutine to capture output
+		done := make(chan bool)
+		go func() {
+			buf.ReadFrom(r)
+			done <- true
+		}()
+
+		// Start profiling
+		var cpuFile, traceF *os.File
+		if config.CPUProfile != "" {
+			cpuFile, _ = os.Create(config.CPUProfile)
+			if cpuFile != nil {
+				pprof.StartCPUProfile(cpuFile)
+			}
+		}
+		if config.TraceFile != "" {
+			traceF, _ = os.Create(config.TraceFile)
+			if traceF != nil {
+				trace.Start(traceF)
+			}
+		}
+
+		// Run benchmark
+		benchResults := runDeviceBenchmark(config)
+
+		// Stop profiling
+		if cpuFile != nil {
+			pprof.StopCPUProfile()
+			cpuFile.Close()
+		}
+		if traceF != nil {
+			trace.Stop()
+			traceF.Close()
+		}
+
+		// Write memory profile
+		if config.MemProfile != "" {
+			memFile, _ := os.Create(config.MemProfile)
+			if memFile != nil {
+				runtime.GC()
+				pprof.WriteHeapProfile(memFile)
+				memFile.Close()
+			}
+		}
+
+		// Print results to buffer
+		printResults(config, benchResults)
+
+		// Restore stdout/stderr
+		w.Close()
+		<-done
+		os.Stdout = oldStdout
+		os.Stderr = oldStderr
+
+		// Save output
+		output := buf.String()
+		if err := os.WriteFile(resultFile, []byte(output), 0644); err != nil {
+			log.Printf("Warning: Failed to write result file: %v", err)
+			results[s.Name] = "FAILED"
+		} else {
+			fmt.Println("  ✓ Complete")
+			results[s.Name] = "SUCCESS"
+		}
+		fmt.Println()
+	}
+
+	// Print summary
+	fmt.Println("========================================")
+	fmt.Println("Benchmarks Complete!")
+	fmt.Println("========================================")
+	fmt.Println()
+	fmt.Println("Results:")
+	for _, s := range toRun {
+		status := results[s.Name]
+		fmt.Printf("  [%s] %s\n", status, s.Name)
+	}
+	fmt.Println()
+	fmt.Printf("Output directory: %s\n", outputDir)
+	fmt.Println()
+	fmt.Println("View results:")
+	fmt.Printf("  cat %s/*_results.txt\n", outputDir)
+	fmt.Println()
+	fmt.Println("Analyze CPU profiles:")
+	fmt.Printf("  go tool pprof %s/*_cpu.prof\n", outputDir)
+	fmt.Println()
+	fmt.Println("Analyze memory profiles:")
+	fmt.Printf("  go tool pprof %s/*_mem.prof\n", outputDir)
+	fmt.Println()
+	fmt.Println("View execution traces:")
+	fmt.Printf("  go tool trace %s/*_trace.out\n", outputDir)
+	fmt.Println()
+
+	// Generate summary file
+	generateSummary(outputDir, toRun)
+}
+
+func runDeviceBenchmark(config BenchmarkConfig) BenchmarkResults {
+	log.Printf("Opening device: %s", config.DevicePath)
+	log.Printf("Format: %dx%d @ %d fps", config.Width, config.Height, config.FPS)
+	log.Printf("Duration: %v, Buffers: %d", config.Duration, config.BufferSize)
+
+	// Open device
+	dev, err := device.Open(
+		config.DevicePath,
+		device.WithBufferSize(config.BufferSize),
+		device.WithPixFormat(v4l2.PixFormat{
+			Width:       config.Width,
+			Height:      config.Height,
+			PixelFormat: config.PixelFormat,
+			Field:       v4l2.FieldNone,
+		}),
+		device.WithFPS(config.FPS),
+	)
+	if err != nil {
+		log.Fatalf("Failed to open device: %v", err)
+	}
+	defer dev.Close()
+
+	// Verify actual format
+	actualFormat, err := dev.GetPixFormat()
+	if err != nil {
+		log.Fatalf("Failed to get format: %v", err)
+	}
+	log.Printf("Actual format: %dx%d, bytesperline=%d, sizeimage=%d",
+		actualFormat.Width, actualFormat.Height,
+		actualFormat.BytesPerLine, actualFormat.SizeImage)
+
+	// Collect memory stats before
+	var memStatsBefore runtime.MemStats
+	runtime.ReadMemStats(&memStatsBefore)
+
+	// Start capture
+	ctx, cancel := context.WithTimeout(context.Background(), config.Duration)
+	defer cancel()
+
+	if err := dev.Start(ctx); err != nil {
+		log.Fatalf("Failed to start capture: %v", err)
+	}
+	defer dev.Stop()
+
+	log.Println("Capturing frames...")
+
+	// Capture loop with timing
+	results := BenchmarkResults{}
+	frameTimes := make([]time.Duration, 0, 1000)
+	lastFrameTime := time.Now()
+	startTime := time.Now()
+
+	for frame := range dev.GetOutput() {
+		now := time.Now()
+		frameTime := now.Sub(lastFrameTime)
+
+		if len(frame) == 0 {
+			results.FramesDropped++
+			if config.Verbose {
+				log.Printf("Frame %d: DROPPED", results.FramesCaptured+results.FramesDropped)
+			}
+		} else {
+			results.FramesCaptured++
+			results.TotalBytes += uint64(len(frame))
+			frameTimes = append(frameTimes, frameTime)
+
+			if config.Verbose && results.FramesCaptured%100 == 0 {
+				log.Printf("Captured %d frames (%.1f fps)", results.FramesCaptured,
+					float64(results.FramesCaptured)/time.Since(startTime).Seconds())
+			}
+		}
+
+		lastFrameTime = now
+	}
+
+	results.Duration = time.Since(startTime)
+
+	// Collect memory stats after
+	var memStatsAfter runtime.MemStats
+	runtime.ReadMemStats(&memStatsAfter)
+
+	// Calculate statistics
+	if results.FramesCaptured > 0 {
+		results.AvgFPS = float64(results.FramesCaptured) / results.Duration.Seconds()
+		results.AvgBytesPerFrame = results.TotalBytes / uint64(results.FramesCaptured)
+
+		// Calculate frame time statistics
+		if len(frameTimes) > 1 {
+			results.MinFrameTime = frameTimes[1] // Skip first
+			results.MaxFrameTime = frameTimes[1]
+			var totalFrameTime time.Duration
+
+			for i := 1; i < len(frameTimes); i++ { // Skip first frame
+				ft := frameTimes[i]
+				totalFrameTime += ft
+				if ft < results.MinFrameTime {
+					results.MinFrameTime = ft
+				}
+				if ft > results.MaxFrameTime {
+					results.MaxFrameTime = ft
+				}
+			}
+			results.AvgFrameTime = totalFrameTime / time.Duration(len(frameTimes)-1)
+		}
+	}
+
+	// Memory statistics
+	results.MemAllocBytes = memStatsAfter.TotalAlloc - memStatsBefore.TotalAlloc
+	results.MemAllocObjects = memStatsAfter.Mallocs - memStatsBefore.Mallocs
+	results.NumGC = memStatsAfter.NumGC - memStatsBefore.NumGC
+	results.GCPauseTotal = time.Duration(memStatsAfter.PauseTotalNs - memStatsBefore.PauseTotalNs)
+
+	return results
+}
+
+func printResults(config BenchmarkConfig, r BenchmarkResults) {
+	separator := strings.Repeat("=", 70)
+	fmt.Println("\n" + separator)
+	fmt.Println("BENCHMARK RESULTS")
+	fmt.Println(separator)
+
+	fmt.Println("\nConfiguration:")
+	fmt.Printf("  Device:        %s\n", config.DevicePath)
+	fmt.Printf("  Resolution:    %dx%d\n", config.Width, config.Height)
+	fmt.Printf("  Target FPS:    %d\n", config.FPS)
+	fmt.Printf("  Duration:      %v\n", config.Duration)
+	fmt.Printf("  Buffers:       %d\n", config.BufferSize)
+
+	fmt.Println("\nCapture Statistics:")
+	fmt.Printf("  Frames Captured:   %d\n", r.FramesCaptured)
+	fmt.Printf("  Frames Dropped:    %d\n", r.FramesDropped)
+	fmt.Printf("  Actual Duration:   %v\n", r.Duration)
+	fmt.Printf("  Average FPS:       %.2f\n", r.AvgFPS)
+	fmt.Printf("  Total Data:        %.2f MB\n", float64(r.TotalBytes)/(1024*1024))
+	fmt.Printf("  Avg Bytes/Frame:   %d\n", r.AvgBytesPerFrame)
+
+	fmt.Println("\nTiming Statistics:")
+	fmt.Printf("  Min Frame Time:    %v\n", r.MinFrameTime)
+	fmt.Printf("  Avg Frame Time:    %v\n", r.AvgFrameTime)
+	fmt.Printf("  Max Frame Time:    %v\n", r.MaxFrameTime)
+	if config.FPS > 0 {
+		targetFrameTime := time.Second / time.Duration(config.FPS)
+		fmt.Printf("  Target Frame Time: %v\n", targetFrameTime)
+	}
+
+	fmt.Println("\nMemory Statistics:")
+	fmt.Printf("  Total Allocated:   %.2f MB\n", float64(r.MemAllocBytes)/(1024*1024))
+	if r.FramesCaptured > 0 {
+		fmt.Printf("  Allocs per Frame:  %.2f MB\n", float64(r.MemAllocBytes)/float64(r.FramesCaptured)/(1024*1024))
+	}
+	fmt.Printf("  Total Allocations: %d\n", r.MemAllocObjects)
+	if r.FramesCaptured > 0 {
+		fmt.Printf("  Allocs per Frame:  %.0f\n", float64(r.MemAllocObjects)/float64(r.FramesCaptured))
+	}
+	fmt.Printf("  GC Runs:           %d\n", r.NumGC)
+	fmt.Printf("  GC Pause Total:    %v\n", r.GCPauseTotal)
+	if r.NumGC > 0 {
+		fmt.Printf("  Avg GC Pause:      %v\n", r.GCPauseTotal/time.Duration(r.NumGC))
+	}
+
+	fmt.Println("\nPerformance Metrics:")
+	if r.AvgFPS > 0 && r.FramesCaptured > 0 {
+		cpuTimePerFrame := r.Duration / time.Duration(r.FramesCaptured)
+		fmt.Printf("  CPU Time/Frame:    %v\n", cpuTimePerFrame)
+		fmt.Printf("  Throughput:        %.2f MB/s\n",
+			float64(r.TotalBytes)/(1024*1024)/r.Duration.Seconds())
+	}
+
+	fmt.Println("\n" + separator)
+
+	if config.CPUProfile != "" {
+		fmt.Printf("\nCPU Profile: %s\n", config.CPUProfile)
+		fmt.Println("Analyze with: go tool pprof " + config.CPUProfile)
+	}
+	if config.MemProfile != "" {
+		fmt.Printf("Memory Profile: %s\n", config.MemProfile)
+		fmt.Println("Analyze with: go tool pprof " + config.MemProfile)
+	}
+	if config.TraceFile != "" {
+		fmt.Printf("Trace File: %s\n", config.TraceFile)
+		fmt.Println("Analyze with: go tool trace " + config.TraceFile)
+	}
+}
+
+func generateSummary(outputDir string, scenarios []BenchmarkScenario) {
+	summaryFile := filepath.Join(outputDir, "summary.txt")
+
+	summary := "# Benchmark Summary\n\n"
+	summary += fmt.Sprintf("Generated: %s\n\n", time.Now().Format(time.RFC3339))
+
+	for _, s := range scenarios {
+		resultFile := filepath.Join(outputDir, fmt.Sprintf("%s_results.txt", s.Name))
+		if _, err := os.Stat(resultFile); os.IsNotExist(err) {
+			continue
+		}
+
+		content, err := os.ReadFile(resultFile)
+		if err != nil {
+			continue
+		}
+
+		summary += fmt.Sprintf("## %s\n\n", s.Name)
+		summary += string(content)
+		summary += "\n\n"
+	}
+
+	if err := os.WriteFile(summaryFile, []byte(summary), 0644); err != nil {
+		log.Printf("Warning: Failed to write summary: %v", err)
+	} else {
+		fmt.Printf("Summary written to: %s\n", summaryFile)
+	}
+}
+
+func parseDuration(s string) time.Duration {
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		log.Fatalf("Invalid duration: %s", s)
+	}
+	return d
+}

--- a/docs/performance-optimization-plan.md
+++ b/docs/performance-optimization-plan.md
@@ -1,0 +1,324 @@
+# Frame Processing Pipeline Performance - Implementation Plan
+
+**Roadmap Item:** #1 - Frame Processing Pipeline Performance
+**Status:** In Progress
+**Started:** 2025-10-11
+
+## Overview
+
+This document tracks the implementation plan for eliminating bottlenecks in the frame processing pipeline to ensure maximum throughput and minimal latency.
+
+---
+
+## Implementation Approach
+
+### Phase 1: Profiling & Bottleneck Identification
+
+#### Step 1: Analyze Current Implementation
+- [ ] Read and analyze the current frame capture loop in `device/device.go:startStreamLoop()`
+- [ ] Identify the frame copy operation at line ~676-677
+- [ ] Map out complete data flow: device → mmap → copy → channel → user
+- [ ] Document current memory allocation patterns
+- [ ] Review channel buffer sizing and blocking behavior
+
+**Key Code Locations:**
+- Frame copy: `device/device.go:676-677`
+- Channel send: `device/device.go:680`
+- Buffer management: `v4l2/streaming.go:MapMemoryBuffers()`
+
+#### Step 2: Create Profiling Infrastructure ✅ COMPLETED
+- [x] Benchmark infrastructure in place (see `benchmark/README.md` for details)
+
+#### Step 3: Identify Specific Bottlenecks
+- [ ] Run baseline benchmarks on current implementation
+- [ ] Profile CPU usage with pprof
+- [ ] Profile memory allocation patterns
+- [ ] Analyze execution trace for goroutine blocking
+- [ ] Measure channel send/receive latency
+- [ ] Document findings in performance report
+
+**Expected Bottlenecks:**
+1. Frame copy operation (line 676-677 allocates + copies every frame)
+2. Channel send blocking when consumer is slow
+3. Memory allocation for each frame (GC pressure)
+4. Potential lock contention in multi-device scenarios
+
+---
+
+### Phase 2: Quick Wins Implementation
+
+#### Option A: Zero-Copy Frame Access (Recommended)
+
+**Goal:** Eliminate frame copy by passing buffer references directly to users
+
+**Implementation Plan:**
+- [ ] Add `WithZeroCopy()` option to device configuration
+- [ ] Create `Frame` type with buffer reference and metadata
+  ```go
+  type Frame struct {
+      Data      []byte  // Reference to mmap buffer (not copy)
+      Index     uint32  // Buffer index
+      Timestamp time.Time
+      Sequence  uint32
+      release   func()  // Callback to release buffer
+  }
+  ```
+- [ ] Implement buffer lifecycle tracking
+  - [ ] Reference counting per buffer
+  - [ ] Release callback mechanism
+  - [ ] Automatic re-queue after release
+- [ ] Update channel type: `chan []byte` → `chan *Frame` (new API)
+- [ ] Add buffer timeout mechanism (force release after N seconds)
+- [ ] Update examples to demonstrate zero-copy usage
+- [ ] Add safety checks (detect use-after-release)
+
+**API Design:**
+```go
+// New zero-copy API
+dev, _ := device.Open("/dev/video0",
+    device.WithZeroCopy(),
+    device.WithBufferSize(4),
+)
+
+for frame := range dev.GetFrames() { // Returns *Frame instead of []byte
+    // Process frame data
+    processFrame(frame.Data)
+
+    // Must explicitly release when done
+    frame.Release()
+}
+```
+
+**Pros:**
+- Maximum performance (no copy overhead)
+- Minimal GC pressure
+- Exposes frame metadata naturally
+
+**Cons:**
+- Breaking API change (need new method)
+- Requires user discipline (must call Release())
+- More complex buffer management
+
+**Estimated Effort:** 2-3 hours
+
+---
+
+#### Option B: Frame Pool Implementation
+
+**Goal:** Reuse allocated frame buffers to reduce GC pressure
+
+**Implementation Plan:**
+- [ ] Create `framePool` using `sync.Pool`
+- [ ] Modify frame copy to use pooled buffers
+- [ ] Return buffers to pool after channel receive
+- [ ] Add pool metrics (hits, misses, size)
+- [ ] Benchmark pool vs non-pool performance
+
+**Implementation:**
+```go
+var framePool = sync.Pool{
+    New: func() interface{} {
+        return make([]byte, 0) // Capacity set on first use
+    },
+}
+
+// In capture loop
+func (d *Device) captureFrame(buff Buffer) {
+    frame := framePool.Get().([]byte)
+    if cap(frame) < int(buff.BytesUsed) {
+        frame = make([]byte, buff.BytesUsed)
+    }
+    frame = frame[:buff.BytesUsed]
+    copy(frame, d.buffers[buff.Index][:buff.BytesUsed])
+    d.output <- frame
+}
+
+// User must return to pool (or use finalizer)
+func ReturnFrame(frame []byte) {
+    framePool.Put(frame[:0])
+}
+```
+
+**Pros:**
+- Compatible with existing API
+- Reduces GC pressure
+- Easy to implement
+
+**Cons:**
+- Still requires frame copy
+- Requires user cooperation to return frames
+- Pool management overhead
+
+**Estimated Effort:** 1-2 hours
+
+---
+
+#### Option C: Configurable Frame Dropping
+
+**Goal:** Handle slow consumers gracefully without blocking capture
+
+**Implementation Plan:**
+- [ ] Add `FrameDropPolicy` enum
+  ```go
+  type FrameDropPolicy int
+  const (
+      DropNever   FrameDropPolicy = iota // Block (current behavior)
+      DropOldest                          // Discard oldest frame in channel
+      DropNewest                          // Skip current frame
+  )
+  ```
+- [ ] Add `WithFrameDropPolicy(policy)` option
+- [ ] Implement non-blocking channel send with drop logic
+- [ ] Add dropped frame counter metric
+- [ ] Expose metrics via `Device.Stats()` method
+
+**Implementation:**
+```go
+// In capture loop
+select {
+case d.output <- frame:
+    // Frame sent successfully
+case <-time.After(0): // Non-blocking
+    switch d.config.dropPolicy {
+    case DropOldest:
+        <-d.output // Discard oldest
+        d.output <- frame
+        d.droppedFrames++
+    case DropNewest:
+        // Skip this frame
+        d.droppedFrames++
+    case DropNever:
+        d.output <- frame // Block
+    }
+}
+```
+
+**Pros:**
+- Simple to implement
+- No API changes required
+- Immediate benefit for high-throughput scenarios
+- Easy to understand
+
+**Cons:**
+- Doesn't eliminate copy overhead
+- Frame dropping may not be acceptable for all use cases
+- Still has GC pressure
+
+**Estimated Effort:** 1 hour
+
+---
+
+### Phase 3: Advanced Optimizations (Future)
+
+- [ ] Implement lock-free ring buffer (replace channels)
+- [ ] Add NUMA-aware buffer allocation
+- [ ] Optimize memory layout for cache efficiency
+- [ ] Implement batch frame processing
+- [ ] Add GPU memory integration (CUDA, OpenCL)
+- [ ] Explore io_uring for async I/O
+
+---
+
+## Session Plan
+
+### Session 1: Profiling Infrastructure ✅ COMPLETED (2025-10-12)
+
+**✅ Benchmark Infrastructure Complete**
+- Benchmark infrastructure in place and documented
+- Tests actual go4vl code paths (device, v4l2 packages)
+- See `benchmark/README.md` for usage details
+
+**Next Session Goals:**
+- [ ] Run baseline measurements
+- [ ] Identify primary bottleneck
+
+**Priority 2: Quick Win Implementation (60-90 min)**
+Choose one based on profiling results:
+- [ ] Option A: Zero-copy mode (if copy is main bottleneck)
+- [ ] Option B: Frame pool (if GC is main bottleneck)
+- [ ] Option C: Frame dropping (if channel blocking is main bottleneck)
+
+**Priority 3: Validation (30 min)**
+- [ ] Run before/after benchmarks
+- [ ] Document performance improvement
+- [ ] Create example demonstrating feature
+- [ ] Update this document with results
+
+---
+
+## Benchmark Results
+
+### Baseline (Current Implementation)
+
+**Test Configuration:**
+- Resolution: TBD
+- Frame Rate: TBD
+- Duration: TBD
+- Device: TBD
+
+**Metrics:**
+- FPS Actual: TBD
+- CPU Usage: TBD
+- Memory/Frame: TBD
+- GC Pauses: TBD
+- Frame Drops: TBD
+
+### After Optimization
+
+**Test Configuration:**
+- Resolution: TBD
+- Frame Rate: TBD
+- Duration: TBD
+- Device: TBD
+- Optimization: TBD
+
+**Metrics:**
+- FPS Actual: TBD
+- CPU Usage: TBD
+- Memory/Frame: TBD
+- GC Pauses: TBD
+- Frame Drops: TBD
+- **Improvement: TBD%**
+
+---
+
+## Decision Log
+
+### 2025-10-11 - Initial Planning
+- Created implementation plan
+- Identified three potential quick wins
+- Decided to start with profiling to guide optimization choice
+
+---
+
+## Next Steps
+
+After completing initial optimization:
+
+1. **Measure Impact**
+   - Run comprehensive benchmarks
+   - Compare against baseline
+   - Document improvement percentage
+
+2. **Iterate**
+   - Identify remaining bottlenecks
+   - Implement next optimization
+   - Repeat profiling cycle
+
+3. **Documentation**
+   - Update API documentation
+   - Create performance tuning guide
+   - Add migration guide if API changes
+
+4. **Testing**
+   - Add performance regression tests
+   - Test on multiple platforms (x86, ARM, ARM64)
+   - Test with various devices and resolutions
+
+---
+
+## References
+
+- Current implementation: `device/device.go:636-697`
+- Buffer management: `v4l2/streaming.go:290-331`
+- Roadmap: `ROADMAP.md` - Enhancement #1

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/vladimirvivien/go4vl
 go 1.25
 
 require golang.org/x/sys v0.37.0
+
+require github.com/vladimirvivien/gexe v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
+github.com/vladimirvivien/gexe v0.5.0 h1:AWBVaYnrTsGYBktXvcO0DfWPeSiZxn6mnQ5nvL+A1/A=
+github.com/vladimirvivien/gexe v0.5.0/go.mod h1:3gjgTqE2c0VyHnU5UOIwk7gyNzZDGulPb/DJPgcw64E=
 golang.org/x/sys v0.37.0 h1:fdNQudmxPjkdUTPnLn5mdQv7Zwvbvpaxqs831goi9kQ=
 golang.org/x/sys v0.37.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=


### PR DESCRIPTION
- Add benchmark runner utility
- Run benchmarks with actual go4vl code paths (device, v4l2 packages)
- Captures CPU, memory, and execution trace profiling
- Can setup v4l2loopback devices for benchmark
- Or target a real device for testing 

See benchmark/README.md for usage details