### PR TITLE
issue-98 - chore: Tuner and Modulator Enumeration

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -116,27 +116,33 @@ This is the primary roadmap for go4vl, tracking implementation of V4L2 (Video fo
 ---
 
 ### 1.6 Tuners and Modulators
-**Status**: ❌ Not Started
+**Status**: ✅ Complete
 
-- [ ] `VIDIOC_G_TUNER` - Get tuner properties
-- [ ] `VIDIOC_S_TUNER` - Set tuner properties
-- [ ] `VIDIOC_G_MODULATOR` - Get modulator properties
-- [ ] `VIDIOC_S_MODULATOR` - Set modulator properties
-- [ ] `VIDIOC_G_FREQUENCY` - Get tuner/modulator frequency
-- [ ] `VIDIOC_S_FREQUENCY` - Set tuner/modulator frequency
-- [ ] `VIDIOC_ENUM_FREQ_BANDS` - Enumerate frequency bands
-- [ ] Tuner capabilities and modes
-- [ ] Signal strength/AFC monitoring
-- [ ] RDS/RBDS support
+- [x] `VIDIOC_G_TUNER` - Get tuner properties
+- [x] `VIDIOC_S_TUNER` - Set tuner properties
+- [x] `VIDIOC_G_MODULATOR` - Get modulator properties
+- [x] `VIDIOC_S_MODULATOR` - Set modulator properties
+- [x] `VIDIOC_G_FREQUENCY` - Get tuner/modulator frequency
+- [x] `VIDIOC_S_FREQUENCY` - Set tuner/modulator frequency
+- [x] `VIDIOC_ENUM_FREQ_BANDS` - Enumerate frequency bands
+- [x] Tuner capabilities and modes
+- [x] Signal strength/AFC monitoring
+- [x] RDS/RBDS support structures
 
 **Priority**: Low (niche hardware - TV tuners, SDR)
 
+**Files**: `v4l2/tuner_info.go`, `device/device.go`
+
+**Tests**: `v4l2/tuner_info_test.go`, `test/tuner_modulator_test.go`
+
+**Examples**: `examples/tuner/`, `examples/modulator/`
+
 **Deliverables**:
-- Create `v4l2/tuner.go`
-- Implement tuner/modulator structures
-- Add frequency control methods
-- Create FM radio tuner example
-- Create TV tuner example
+- ✅ Create `v4l2/tuner_info.go`
+- ✅ Implement tuner/modulator structures
+- ✅ Add frequency control methods
+- ✅ Create tuner example (radio/TV)
+- ✅ Create modulator example
 
 ---
 

--- a/device/device.go
+++ b/device/device.go
@@ -821,6 +821,171 @@ func (d *Device) SetAudioOutMode(mode v4l2.AudioMode) error {
 	return v4l2.SetAudioOutMode(d.fd, mode)
 }
 
+// GetTunerInfo returns information about a specific tuner.
+//
+// Parameters:
+//   - index: Zero-based index of the tuner to query
+//
+// The returned TunerInfo includes the tuner name, type, capabilities,
+// frequency range, signal strength, and audio mode.
+//
+// Example:
+//
+//	tuner, err := dev.GetTunerInfo(0)
+//	if err == nil {
+//	    log.Printf("Tuner: %s, Type: %s, Signal: %d\n",
+//	        tuner.GetName(),
+//	        v4l2.TunerTypes[tuner.GetType()],
+//	        tuner.GetSignal())
+//	}
+func (d *Device) GetTunerInfo(index uint32) (v4l2.TunerInfo, error) {
+	return v4l2.GetTunerInfo(d.fd, index)
+}
+
+// GetAllTuners returns all tuners supported by the device.
+// Each tuner description includes the name, type, capabilities, and frequency range.
+//
+// This is useful for discovering available tuners before tuning.
+//
+// Example:
+//
+//	tuners, err := dev.GetAllTuners()
+//	for _, tuner := range tuners {
+//	    log.Printf("Tuner %d: %s (%s), Range: %d-%d\n",
+//	        tuner.GetIndex(), tuner.GetName(),
+//	        v4l2.TunerTypes[tuner.GetType()],
+//	        tuner.GetRangeLow(), tuner.GetRangeHigh())
+//	}
+func (d *Device) GetAllTuners() ([]v4l2.TunerInfo, error) {
+	return v4l2.GetAllTuners(d.fd)
+}
+
+// SetTuner sets tuner parameters such as audio mode.
+//
+// Parameters:
+//   - tuner: TunerInfo struct with desired settings
+//
+// Example:
+//
+//	tuner, _ := dev.GetTunerInfo(0)
+//	// Modify tuner settings as needed
+//	err := dev.SetTuner(tuner)
+func (d *Device) SetTuner(tuner v4l2.TunerInfo) error {
+	return v4l2.SetTuner(d.fd, tuner)
+}
+
+// GetFrequency returns the current frequency for the specified tuner.
+//
+// Parameters:
+//   - tunerIndex: Zero-based index of the tuner
+//
+// Returns FrequencyInfo containing the frequency in device-specific units.
+// Use TunerInfo.IsLowFreq() to determine if units are 1/16 kHz (true) or 1/16 MHz (false).
+//
+// Example:
+//
+//	freq, err := dev.GetFrequency(0)
+//	if err == nil {
+//	    log.Printf("Current frequency: %d\n", freq.GetFrequency())
+//	}
+func (d *Device) GetFrequency(tunerIndex uint32) (v4l2.FrequencyInfo, error) {
+	return v4l2.GetFrequency(d.fd, tunerIndex)
+}
+
+// SetFrequency sets the tuner frequency.
+//
+// Parameters:
+//   - tunerIndex: Zero-based index of the tuner
+//   - tunerType: Type of tuner (e.g., v4l2.TunerTypeRadio, v4l2.TunerTypeAnalogTV)
+//   - frequency: Frequency in device-specific units (check TunerInfo.IsLowFreq())
+//
+// For radio tuners with TunerCapLow capability:
+//   - Units are 1/16000 kHz (62.5 Hz)
+//   - Example: 100.5 MHz = 100500 kHz = 100500 * 16 = 1,608,000 units
+//
+// For tuners without TunerCapLow:
+//   - Units are 1/16 MHz (62.5 kHz)
+//
+// Example:
+//
+//	// Set FM radio to 100.5 MHz (assuming TunerCapLow)
+//	err := dev.SetFrequency(0, v4l2.TunerTypeRadio, 1608000)
+func (d *Device) SetFrequency(tunerIndex uint32, tunerType v4l2.TunerType, frequency uint32) error {
+	return v4l2.SetFrequency(d.fd, tunerIndex, tunerType, frequency)
+}
+
+// GetFrequencyBands returns all frequency bands for the specified tuner.
+//
+// Parameters:
+//   - tunerIndex: Zero-based index of the tuner
+//   - tunerType: Type of tuner (e.g., v4l2.TunerTypeRadio)
+//
+// Example:
+//
+//	bands, err := dev.GetFrequencyBands(0, v4l2.TunerTypeRadio)
+//	for _, band := range bands {
+//	    log.Printf("Band %d: %d-%d, Modulation: FM=%v AM=%v\n",
+//	        band.GetIndex(),
+//	        band.GetRangeLow(), band.GetRangeHigh(),
+//	        band.GetModulation()&v4l2.BandModulationFM != 0,
+//	        band.GetModulation()&v4l2.BandModulationAM != 0)
+//	}
+func (d *Device) GetFrequencyBands(tunerIndex uint32, tunerType v4l2.TunerType) ([]v4l2.FrequencyBandInfo, error) {
+	return v4l2.GetAllFrequencyBands(d.fd, tunerIndex, tunerType)
+}
+
+// GetModulatorInfo returns information about a specific modulator.
+//
+// Parameters:
+//   - index: Zero-based index of the modulator to query
+//
+// The returned ModulatorInfo includes the modulator name, type, capabilities,
+// and frequency range.
+//
+// Example:
+//
+//	mod, err := dev.GetModulatorInfo(0)
+//	if err == nil {
+//	    log.Printf("Modulator: %s, Type: %s\n",
+//	        mod.GetName(),
+//	        v4l2.TunerTypes[mod.GetType()])
+//	}
+func (d *Device) GetModulatorInfo(index uint32) (v4l2.ModulatorInfo, error) {
+	return v4l2.GetModulatorInfo(d.fd, index)
+}
+
+// GetAllModulators returns all modulators supported by the device.
+// Each modulator description includes the name, type, capabilities, and frequency range.
+//
+// This is useful for discovering available modulators before transmission.
+//
+// Example:
+//
+//	modulators, err := dev.GetAllModulators()
+//	for _, mod := range modulators {
+//	    log.Printf("Modulator %d: %s (%s), Range: %d-%d\n",
+//	        mod.GetIndex(), mod.GetName(),
+//	        v4l2.TunerTypes[mod.GetType()],
+//	        mod.GetRangeLow(), mod.GetRangeHigh())
+//	}
+func (d *Device) GetAllModulators() ([]v4l2.ModulatorInfo, error) {
+	return v4l2.GetAllModulators(d.fd)
+}
+
+// SetModulator sets modulator parameters such as transmission subchannels.
+//
+// Parameters:
+//   - modulator: ModulatorInfo struct with desired settings
+//
+// Example:
+//
+//	mod, _ := dev.GetModulatorInfo(0)
+//	// Modify modulator settings as needed
+//	err := dev.SetModulator(mod)
+func (d *Device) SetModulator(modulator v4l2.ModulatorInfo) error {
+	return v4l2.SetModulator(d.fd, modulator)
+}
+
 // GetStreamParam returns the current streaming parameters including
 // capture/output timing, buffer settings, and capability flags.
 //

--- a/examples/README.md
+++ b/examples/README.md
@@ -15,6 +15,8 @@
 * [video_outputs](./video_outputs/) - Enumerate and select video outputs (for output devices and v4l2loopback).
 * [audio_inputs](./audio_inputs/) - Enumerate and select audio inputs (for webcams with mics, TV tuner cards).
 * [audio_outputs](./audio_outputs/) - Enumerate and select audio outputs (for video output devices).
+* [tuner](./tuner/) - Enumerate tuners, get/set frequency, and query signal strength (for radio/TV tuners, SDR devices).
+* [modulator](./modulator/) - Enumerate modulators and control transmission frequency (for RF modulators, transmitters).
 * [ext_ctrls](./ext_ctrls/) Shows how to query and apply extended controls.
 * [user_ctrl](./user_ctrl/) Shows how to query and apply user controls.
 

--- a/examples/modulator/README.md
+++ b/examples/modulator/README.md
@@ -1,0 +1,169 @@
+# Modulator Example
+
+This example demonstrates how to enumerate and control modulators on V4L2 devices.
+
+## Overview
+
+Modulators are used to transmit radio frequency signals. Common devices with modulators include:
+- **RF modulators** for video output (TV channel modulation)
+- **TV transmitters**
+- **FM/AM radio transmitters**
+- **Software Defined Radio (SDR) devices** with transmission capability
+
+**⚠️ Warning**: Operating radio transmitters may require licensing in your jurisdiction. Always comply with local regulations regarding radio frequency transmission.
+
+## Features Demonstrated
+
+- Enumerate all available modulators
+- Display modulator capabilities (stereo, RDS, etc.)
+- Query current transmission frequency
+- Set modulator frequency
+- Enumerate frequency bands (if supported)
+- Display transmission subchannel configuration
+
+## Usage
+
+```bash
+# Build the example
+go build
+
+# List all modulators on the default device
+./modulator
+
+# Use a specific device
+./modulator -d /dev/video1
+
+# Show frequency bands
+./modulator -b
+
+# Set transmission frequency (example for UHF TV channel)
+./modulator -f 7584  # 474 MHz (example)
+
+# Combine options
+./modulator -d /dev/video0 -b -f 7584
+```
+
+## Command-line Options
+
+- `-d <device>` - Device path (default: `/dev/video0`)
+- `-f <frequency>` - Set transmission frequency in device-specific units
+- `-b` - Show frequency bands
+
+## Understanding Frequency Units
+
+V4L2 uses two different frequency unit systems depending on the modulator capability:
+
+### Low Frequency Units (TunerCapLow)
+- **Unit**: 1/16000 kHz = 62.5 Hz
+- **Common for**: FM/AM radio modulators
+- **Example**: To transmit on 100.5 MHz FM:
+  - 100.5 MHz = 100,500 kHz
+  - Frequency units = 100,500 × 16 = 1,608,000
+
+### High Frequency Units (Normal)
+- **Unit**: 1/16 MHz = 62.5 kHz
+- **Common for**: TV modulators
+- **Example**: To transmit on 474 MHz (UHF TV):
+  - Frequency units = 474 × 16 = 7,584
+
+## Example Output
+
+```
+Device: /dev/video0
+Driver: example-modulator
+Card: Example RF Modulator
+
+Available modulators (1):
+================================================================================
+[0] RF Modulator
+    Type:       Analog TV
+    Capability: 0x00001012
+    Range:      880 - 13760 (units: 62.5 kHz)
+                55.0 - 860.0 MHz
+    TxSubchans: 0x1 (Mono)
+    Features:   None
+
+Current Frequency (Modulator 0):
+================================================================================
+Modulator:  0
+Type:       Analog TV
+Frequency:  7584 (474.0 MHz)
+
+Tip: Use -f <frequency> to set modulator frequency
+     Units are 1/16 MHz (62.5 kHz)
+Tip: Use -b to show available frequency bands
+```
+
+## Modulator Capabilities
+
+The example displays the following modulator capabilities:
+
+- **Stereo**: Modulator supports stereo audio transmission
+- **RDS**: Radio Data System support (FM transmission)
+- **Freq Bands**: Multiple frequency bands support
+
+## Frequency Bands
+
+Some modulators support multiple frequency bands with different characteristics. Use the `-b` flag to enumerate them:
+
+```bash
+./modulator -b
+```
+
+Example output:
+```
+Frequency Bands (Modulator 0):
+================================================================================
+Band 0:
+  Range:      880 - 1520 (55.0 - 95.0 MHz)
+  Capability: 0x00001002
+  Modulation: 0x4 (FM)
+
+Band 1:
+  Range:      2880 - 4320 (180.0 - 270.0 MHz)
+  Capability: 0x00001002
+  Modulation: 0x2 (VSB)
+```
+
+## Common Use Cases
+
+### RF Video Modulator
+
+RF modulators are commonly used to transmit composite video on a TV channel:
+
+```bash
+# Set modulator to channel 3 (typically 61.25 MHz for NTSC)
+# 61.25 MHz = 61250 kHz × 16 = 980,000 units (if TunerCapLow)
+# OR 61.25 MHz ÷ 62.5 kHz = 980 units (if normal)
+./modulator -d /dev/video0 -f 980
+```
+
+### FM Radio Transmission
+
+```bash
+# Transmit on 88.5 MHz FM (where legal)
+# 88.5 MHz = 88500 kHz × 16 = 1,416,000 units (if TunerCapLow)
+./modulator -d /dev/radio0 -f 1416000
+```
+
+## Regulatory Compliance
+
+**IMPORTANT**:
+- Radio frequency transmission is regulated in most countries
+- Operating a transmitter without proper authorization may be illegal
+- Always check your local regulations before transmitting
+- This example is for educational purposes and authorized use only
+- Unlicensed low-power devices may have specific frequency and power restrictions
+
+## Notes
+
+- Not all V4L2 devices have modulators (modulators are much less common than tuners)
+- Frequency units vary by device (check `IsLowFreq()`)
+- Some devices may restrict frequency setting for regulatory compliance
+- Transmission subchannels (`TxSubchans`) control audio mode (mono/stereo/RDS)
+
+## See Also
+
+- [V4L2 Modulator API Documentation](https://linuxtv.org/downloads/v4l-dvb-apis/userspace-api/v4l/vidioc-g-modulator.html)
+- [V4L2 Frequency API Documentation](https://linuxtv.org/downloads/v4l-dvb-apis/userspace-api/v4l/vidioc-g-frequency.html)
+- Related example: `examples/tuner` - For RF reception

--- a/examples/modulator/main.go
+++ b/examples/modulator/main.go
@@ -1,0 +1,245 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+
+	"github.com/vladimirvivien/go4vl/device"
+	"github.com/vladimirvivien/go4vl/v4l2"
+)
+
+func main() {
+	var devName string
+	var setFreq int
+	var showBands bool
+	flag.StringVar(&devName, "d", "/dev/video0", "device name (path)")
+	flag.IntVar(&setFreq, "f", -1, "set modulator frequency (in device units, optional)")
+	flag.BoolVar(&showBands, "b", false, "show frequency bands")
+	flag.Parse()
+
+	dev, err := device.Open(devName)
+	if err != nil {
+		log.Fatalf("Failed to open device %s: %v", devName, err)
+	}
+	defer dev.Close()
+
+	fmt.Printf("Device: %s\n", dev.Name())
+	fmt.Printf("Driver: %s\n", dev.Capability().Driver)
+	fmt.Printf("Card: %s\n\n", dev.Capability().Card)
+
+	// Enumerate all modulators
+	modulators, err := dev.GetAllModulators()
+	if err != nil {
+		fmt.Printf("Device does not support modulators: %v\n", err)
+		fmt.Println("\nNote: Modulators are typically found on:")
+		fmt.Println("  - RF modulators for video output")
+		fmt.Println("  - TV transmitters")
+		fmt.Println("  - FM/AM radio transmitters")
+		fmt.Println("  - Software Defined Radio (SDR) devices with TX capability")
+		return
+	}
+
+	if len(modulators) == 0 {
+		fmt.Println("No modulators found")
+		return
+	}
+
+	fmt.Printf("Available modulators (%d):\n", len(modulators))
+	fmt.Println("================================================================================")
+	for _, mod := range modulators {
+		displayModulator(mod)
+	}
+
+	// Get current frequency for first modulator (uses same API as tuner)
+	if len(modulators) > 0 {
+		freq, err := dev.GetFrequency(0)
+		if err == nil {
+			fmt.Println("\nCurrent Frequency (Modulator 0):")
+			fmt.Println("================================================================================")
+			displayFrequency(freq, modulators[0])
+		}
+	}
+
+	// Show frequency bands if requested
+	if showBands && len(modulators) > 0 {
+		mod := modulators[0]
+		if mod.SupportsFreqBands() {
+			bands, err := dev.GetFrequencyBands(0, mod.GetType())
+			if err == nil && len(bands) > 0 {
+				fmt.Println("\nFrequency Bands (Modulator 0):")
+				fmt.Println("================================================================================")
+				for _, band := range bands {
+					displayBand(band, mod)
+				}
+			} else if err != nil {
+				fmt.Printf("\nFailed to get frequency bands: %v\n", err)
+			}
+		} else {
+			fmt.Println("\nModulator does not support frequency band enumeration")
+		}
+	}
+
+	// Set frequency if requested
+	if setFreq >= 0 && len(modulators) > 0 {
+		mod := modulators[0]
+		fmt.Printf("\nSetting modulator frequency to %d...\n", setFreq)
+		err = dev.SetFrequency(0, mod.GetType(), uint32(setFreq))
+		if err != nil {
+			log.Fatalf("Failed to set frequency: %v", err)
+		}
+
+		// Verify the change
+		newFreq, err := dev.GetFrequency(0)
+		if err != nil {
+			log.Fatalf("Failed to verify frequency: %v", err)
+		}
+
+		if newFreq.GetFrequency() == uint32(setFreq) {
+			fmt.Printf("✓ Successfully set modulator frequency to %d\n", setFreq)
+		} else {
+			fmt.Printf("⚠ Frequency may not have changed exactly (got %d, requested %d)\n",
+				newFreq.GetFrequency(), setFreq)
+		}
+	} else if len(modulators) > 0 {
+		fmt.Println("\nTip: Use -f <frequency> to set modulator frequency")
+		if modulators[0].IsLowFreq() {
+			fmt.Println("     Units are 1/16000 kHz (62.5 Hz)")
+			fmt.Println("     Example: -f 1608000 for 100.5 MHz (FM)")
+		} else {
+			fmt.Println("     Units are 1/16 MHz (62.5 kHz)")
+		}
+		fmt.Println("Tip: Use -b to show available frequency bands")
+	}
+}
+
+func displayModulator(mod v4l2.ModulatorInfo) {
+	typeName := v4l2.TunerTypes[mod.GetType()]
+	if typeName == "" {
+		typeName = fmt.Sprintf("Unknown (0x%x)", mod.GetType())
+	}
+
+	fmt.Printf("[%d] %s\n", mod.GetIndex(), mod.GetName())
+	fmt.Printf("    Type:       %s\n", typeName)
+	fmt.Printf("    Capability: 0x%08x\n", mod.GetCapability())
+
+	// Display frequency range
+	rangeLow := mod.GetRangeLow()
+	rangeHigh := mod.GetRangeHigh()
+	if mod.IsLowFreq() {
+		// Units are 1/16000 kHz (62.5 Hz)
+		fmt.Printf("    Range:      %d - %d (units: 62.5 Hz)\n", rangeLow, rangeHigh)
+		fmt.Printf("                %.3f - %.3f MHz\n",
+			float64(rangeLow)/16000.0, float64(rangeHigh)/16000.0)
+	} else {
+		// Units are 1/16 MHz (62.5 kHz)
+		fmt.Printf("    Range:      %d - %d (units: 62.5 kHz)\n", rangeLow, rangeHigh)
+		fmt.Printf("                %.1f - %.1f MHz\n",
+			float64(rangeLow)/16.0, float64(rangeHigh)/16.0)
+	}
+
+	// Display transmission subchannels
+	txSubchans := mod.GetTxSubchans()
+	if txSubchans != 0 {
+		fmt.Printf("    TxSubchans: 0x%x", txSubchans)
+		if txSubchans&v4l2.TunerSubStereo != 0 {
+			fmt.Print(" (Stereo)")
+		}
+		if txSubchans&v4l2.TunerSubMono != 0 {
+			fmt.Print(" (Mono)")
+		}
+		if txSubchans&v4l2.TunerSubRDS != 0 {
+			fmt.Print(" (RDS)")
+		}
+		fmt.Println()
+	}
+
+	// Display capability flags
+	fmt.Print("    Features:   ")
+	features := []string{}
+	if mod.IsStereo() {
+		features = append(features, "Stereo")
+	}
+	if mod.HasRDS() {
+		features = append(features, "RDS")
+	}
+	if mod.SupportsFreqBands() {
+		features = append(features, "Freq Bands")
+	}
+	if len(features) > 0 {
+		for i, feat := range features {
+			if i > 0 {
+				fmt.Print(", ")
+			}
+			fmt.Print(feat)
+		}
+	} else {
+		fmt.Print("None")
+	}
+	fmt.Println()
+	fmt.Println()
+}
+
+func displayFrequency(freq v4l2.FrequencyInfo, mod v4l2.ModulatorInfo) {
+	typeName := v4l2.TunerTypes[freq.GetType()]
+	if typeName == "" {
+		typeName = fmt.Sprintf("Unknown (0x%x)", freq.GetType())
+	}
+
+	fmt.Printf("Modulator:  %d\n", freq.GetTuner())
+	fmt.Printf("Type:       %s\n", typeName)
+	fmt.Printf("Frequency:  %d", freq.GetFrequency())
+
+	if mod.IsLowFreq() {
+		// Units are 1/16000 kHz (62.5 Hz)
+		fmt.Printf(" (%.3f MHz)\n", float64(freq.GetFrequency())/16000.0)
+	} else {
+		// Units are 1/16 MHz (62.5 kHz)
+		fmt.Printf(" (%.1f MHz)\n", float64(freq.GetFrequency())/16.0)
+	}
+}
+
+func displayBand(band v4l2.FrequencyBandInfo, mod v4l2.ModulatorInfo) {
+	fmt.Printf("Band %d:\n", band.GetIndex())
+
+	// Display frequency range
+	rangeLow := band.GetRangeLow()
+	rangeHigh := band.GetRangeHigh()
+	if mod.IsLowFreq() {
+		fmt.Printf("  Range:      %d - %d (%.3f - %.3f MHz)\n",
+			rangeLow, rangeHigh,
+			float64(rangeLow)/16000.0, float64(rangeHigh)/16000.0)
+	} else {
+		fmt.Printf("  Range:      %d - %d (%.1f - %.1f MHz)\n",
+			rangeLow, rangeHigh,
+			float64(rangeLow)/16.0, float64(rangeHigh)/16.0)
+	}
+
+	fmt.Printf("  Capability: 0x%08x\n", band.GetCapability())
+
+	// Display modulation
+	modulation := band.GetModulation()
+	fmt.Printf("  Modulation: 0x%x", modulation)
+	mods := []string{}
+	if modulation&v4l2.BandModulationFM != 0 {
+		mods = append(mods, "FM")
+	}
+	if modulation&v4l2.BandModulationAM != 0 {
+		mods = append(mods, "AM")
+	}
+	if modulation&v4l2.BandModulationVSB != 0 {
+		mods = append(mods, "VSB")
+	}
+	if len(mods) > 0 {
+		fmt.Print(" (")
+		for i, mod := range mods {
+			if i > 0 {
+				fmt.Print(", ")
+			}
+			fmt.Print(mod)
+		}
+		fmt.Print(")")
+	}
+	fmt.Println()
+	fmt.Println()
+}

--- a/examples/tuner/README.md
+++ b/examples/tuner/README.md
@@ -1,0 +1,158 @@
+# Tuner Example
+
+This example demonstrates how to enumerate and control tuners on V4L2 devices.
+
+## Overview
+
+Tuners are used to receive radio frequency signals. Common devices with tuners include:
+- **TV tuner cards** (analog and digital TV)
+- **FM/AM radio receivers**
+- **Software Defined Radio (SDR) devices**
+- **RF receivers**
+
+## Features Demonstrated
+
+- Enumerate all available tuners
+- Display tuner capabilities (stereo, RDS, hardware seek, etc.)
+- Query current frequency
+- Set tuner frequency
+- Enumerate frequency bands (if supported)
+- Display signal strength and AFC (Automatic Frequency Control)
+
+## Usage
+
+```bash
+# Build the example
+go build
+
+# List all tuners on the default device
+./tuner
+
+# Use a specific device
+./tuner -d /dev/video1
+
+# Show frequency bands
+./tuner -b
+
+# Set frequency (example for FM radio at 100.5 MHz)
+# For tuners with TunerCapLow: 100.5 MHz = 100500 kHz = 100500 * 16 = 1,608,000 units
+./tuner -f 1608000
+
+# Combine options
+./tuner -d /dev/radio0 -b -f 1608000
+```
+
+## Command-line Options
+
+- `-d <device>` - Device path (default: `/dev/video0`)
+- `-f <frequency>` - Set frequency in device-specific units
+- `-b` - Show frequency bands
+
+## Understanding Frequency Units
+
+V4L2 uses two different frequency unit systems depending on the tuner capability:
+
+### Low Frequency Units (TunerCapLow)
+- **Unit**: 1/16000 kHz = 62.5 Hz
+- **Common for**: FM/AM radio tuners
+- **Example**: To tune to 100.5 MHz FM radio:
+  - 100.5 MHz = 100,500 kHz
+  - Frequency units = 100,500 × 16 = 1,608,000
+
+### High Frequency Units (Normal)
+- **Unit**: 1/16 MHz = 62.5 kHz
+- **Common for**: TV tuners
+- **Example**: To tune to 474 MHz (TV channel):
+  - Frequency units = 474 × 16 = 7,584
+
+## Example Output
+
+```
+Device: /dev/radio0
+Driver: radio-si470x
+Card: Silicon Labs Si470x FM Radio Receiver
+
+Available tuners (1):
+================================================================================
+[0] FM Radio
+    Type:       Radio
+    Capability: 0x00001091
+    Range:      1408000 - 1728000 (units: 62.5 Hz)
+                88.000 - 108.000 MHz
+    Signal:     32768 / 65535 (50.0%)
+    Audio Mode: Stereo
+    RxSubchans: 0x2 (Stereo)
+    Features:   Stereo, RDS, HW Seek
+
+Current Frequency (Tuner 0):
+================================================================================
+Tuner:      0
+Type:       Radio
+Frequency:  1608000 (100.500 MHz)
+
+Tip: Use -f <frequency> to tune to a specific frequency
+     Units are 1/16000 kHz (62.5 Hz)
+     Example: -f 1608000 for 100.5 MHz (FM radio)
+Tip: Use -b to show available frequency bands
+```
+
+## Tuner Capabilities
+
+The example displays the following tuner capabilities:
+
+- **Stereo**: Tuner supports stereo audio reception
+- **RDS**: Radio Data System support (FM radio)
+- **HW Seek**: Hardware-assisted frequency scanning
+- **Freq Bands**: Multiple frequency bands support
+
+## Frequency Bands
+
+Some tuners support multiple frequency bands with different characteristics. Use the `-b` flag to enumerate them:
+
+```bash
+./tuner -b
+```
+
+Example output:
+```
+Frequency Bands (Tuner 0):
+================================================================================
+Band 0:
+  Range:      1408000 - 1728000 (88.000 - 108.000 MHz)
+  Capability: 0x00001091
+  Modulation: 0x4 (FM)
+```
+
+## Common Use Cases
+
+### FM Radio Tuning
+
+```bash
+# Tune to your favorite FM station (e.g., 95.5 MHz)
+# Calculation: 95.5 MHz = 95500 kHz × 16 = 1,528,000 units
+./tuner -d /dev/radio0 -f 1528000
+```
+
+### Checking Signal Strength
+
+```bash
+# View current signal strength
+./tuner -d /dev/radio0
+```
+
+The signal strength is displayed as a value from 0 to 65535, where:
+- 0 = No signal
+- 65535 = Maximum signal
+
+## Notes
+
+- Not all V4L2 devices have tuners
+- Frequency units vary by device (check `IsLowFreq()`)
+- Some devices may restrict frequency setting for regulatory reasons
+- RDS data reception requires additional V4L2 event handling (not shown in this example)
+
+## See Also
+
+- [V4L2 Tuner API Documentation](https://linuxtv.org/downloads/v4l-dvb-apis/userspace-api/v4l/vidioc-g-tuner.html)
+- [V4L2 Frequency API Documentation](https://linuxtv.org/downloads/v4l-dvb-apis/userspace-api/v4l/vidioc-g-frequency.html)
+- Related example: `examples/modulator` - For RF transmission

--- a/examples/tuner/main.go
+++ b/examples/tuner/main.go
@@ -1,0 +1,268 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+
+	"github.com/vladimirvivien/go4vl/device"
+	"github.com/vladimirvivien/go4vl/v4l2"
+)
+
+func main() {
+	var devName string
+	var setFreq int
+	var showBands bool
+	flag.StringVar(&devName, "d", "/dev/video0", "device name (path)")
+	flag.IntVar(&setFreq, "f", -1, "set frequency (in device units, optional)")
+	flag.BoolVar(&showBands, "b", false, "show frequency bands")
+	flag.Parse()
+
+	dev, err := device.Open(devName)
+	if err != nil {
+		log.Fatalf("Failed to open device %s: %v", devName, err)
+	}
+	defer dev.Close()
+
+	fmt.Printf("Device: %s\n", dev.Name())
+	fmt.Printf("Driver: %s\n", dev.Capability().Driver)
+	fmt.Printf("Card: %s\n\n", dev.Capability().Card)
+
+	// Enumerate all tuners
+	tuners, err := dev.GetAllTuners()
+	if err != nil {
+		fmt.Printf("Device does not support tuners: %v\n", err)
+		fmt.Println("\nNote: Tuners are typically found on:")
+		fmt.Println("  - TV tuner cards (analog/digital)")
+		fmt.Println("  - FM/AM radio receivers")
+		fmt.Println("  - Software Defined Radio (SDR) devices")
+		fmt.Println("  - RF receivers")
+		return
+	}
+
+	if len(tuners) == 0 {
+		fmt.Println("No tuners found")
+		return
+	}
+
+	fmt.Printf("Available tuners (%d):\n", len(tuners))
+	fmt.Println("================================================================================")
+	for _, tuner := range tuners {
+		displayTuner(tuner)
+	}
+
+	// Get current frequency for first tuner
+	if len(tuners) > 0 {
+		freq, err := dev.GetFrequency(0)
+		if err == nil {
+			fmt.Println("\nCurrent Frequency (Tuner 0):")
+			fmt.Println("================================================================================")
+			displayFrequency(freq, tuners[0])
+		}
+	}
+
+	// Show frequency bands if requested
+	if showBands && len(tuners) > 0 {
+		tuner := tuners[0]
+		if tuner.SupportsFreqBands() {
+			bands, err := dev.GetFrequencyBands(0, tuner.GetType())
+			if err == nil && len(bands) > 0 {
+				fmt.Println("\nFrequency Bands (Tuner 0):")
+				fmt.Println("================================================================================")
+				for _, band := range bands {
+					displayBand(band, tuner)
+				}
+			} else if err != nil {
+				fmt.Printf("\nFailed to get frequency bands: %v\n", err)
+			}
+		} else {
+			fmt.Println("\nTuner does not support frequency band enumeration")
+		}
+	}
+
+	// Set frequency if requested
+	if setFreq >= 0 && len(tuners) > 0 {
+		tuner := tuners[0]
+		fmt.Printf("\nSetting frequency to %d...\n", setFreq)
+		err = dev.SetFrequency(0, tuner.GetType(), uint32(setFreq))
+		if err != nil {
+			log.Fatalf("Failed to set frequency: %v", err)
+		}
+
+		// Verify the change
+		newFreq, err := dev.GetFrequency(0)
+		if err != nil {
+			log.Fatalf("Failed to verify frequency: %v", err)
+		}
+
+		if newFreq.GetFrequency() == uint32(setFreq) {
+			fmt.Printf("✓ Successfully set frequency to %d\n", setFreq)
+		} else {
+			fmt.Printf("⚠ Frequency may not have changed exactly (got %d, requested %d)\n",
+				newFreq.GetFrequency(), setFreq)
+		}
+	} else if len(tuners) > 0 {
+		fmt.Println("\nTip: Use -f <frequency> to tune to a specific frequency")
+		if tuners[0].IsLowFreq() {
+			fmt.Println("     Units are 1/16000 kHz (62.5 Hz)")
+			fmt.Println("     Example: -f 1608000 for 100.5 MHz (FM radio)")
+		} else {
+			fmt.Println("     Units are 1/16 MHz (62.5 kHz)")
+		}
+		fmt.Println("Tip: Use -b to show available frequency bands")
+	}
+}
+
+func displayTuner(tuner v4l2.TunerInfo) {
+	typeName := v4l2.TunerTypes[tuner.GetType()]
+	if typeName == "" {
+		typeName = fmt.Sprintf("Unknown (0x%x)", tuner.GetType())
+	}
+
+	fmt.Printf("[%d] %s\n", tuner.GetIndex(), tuner.GetName())
+	fmt.Printf("    Type:       %s\n", typeName)
+	fmt.Printf("    Capability: 0x%08x\n", tuner.GetCapability())
+
+	// Display frequency range
+	rangeLow := tuner.GetRangeLow()
+	rangeHigh := tuner.GetRangeHigh()
+	if tuner.IsLowFreq() {
+		// Units are 1/16000 kHz (62.5 Hz)
+		fmt.Printf("    Range:      %d - %d (units: 62.5 Hz)\n", rangeLow, rangeHigh)
+		fmt.Printf("                %.3f - %.3f MHz\n",
+			float64(rangeLow)/16000.0, float64(rangeHigh)/16000.0)
+	} else {
+		// Units are 1/16 MHz (62.5 kHz)
+		fmt.Printf("    Range:      %d - %d (units: 62.5 kHz)\n", rangeLow, rangeHigh)
+		fmt.Printf("                %.1f - %.1f MHz\n",
+			float64(rangeLow)/16.0, float64(rangeHigh)/16.0)
+	}
+
+	// Display signal info
+	signal := tuner.GetSignal()
+	if signal > 0 {
+		fmt.Printf("    Signal:     %d / 65535 (%.1f%%)\n", signal, float64(signal)/655.35)
+	} else if signal == 0 {
+		fmt.Printf("    Signal:     No signal detected\n")
+	}
+
+	afc := tuner.GetAFC()
+	if afc != 0 {
+		fmt.Printf("    AFC:        %d\n", afc)
+	}
+
+	// Display audio info
+	audioMode := tuner.GetAudioMode()
+	if modeName, ok := v4l2.TunerAudioModes[audioMode]; ok {
+		fmt.Printf("    Audio Mode: %s\n", modeName)
+	} else {
+		fmt.Printf("    Audio Mode: 0x%x\n", audioMode)
+	}
+
+	rxSubchans := tuner.GetRxSubchans()
+	if rxSubchans != 0 {
+		fmt.Printf("    RxSubchans: 0x%x", rxSubchans)
+		if rxSubchans&v4l2.TunerSubStereo != 0 {
+			fmt.Print(" (Stereo)")
+		}
+		if rxSubchans&v4l2.TunerSubMono != 0 {
+			fmt.Print(" (Mono)")
+		}
+		if rxSubchans&v4l2.TunerSubRDS != 0 {
+			fmt.Print(" (RDS)")
+		}
+		fmt.Println()
+	}
+
+	// Display capability flags
+	fmt.Print("    Features:   ")
+	features := []string{}
+	if tuner.IsStereo() {
+		features = append(features, "Stereo")
+	}
+	if tuner.HasRDS() {
+		features = append(features, "RDS")
+	}
+	if tuner.SupportsHwSeek() {
+		features = append(features, "HW Seek")
+	}
+	if tuner.SupportsFreqBands() {
+		features = append(features, "Freq Bands")
+	}
+	if len(features) > 0 {
+		for i, feat := range features {
+			if i > 0 {
+				fmt.Print(", ")
+			}
+			fmt.Print(feat)
+		}
+	} else {
+		fmt.Print("None")
+	}
+	fmt.Println()
+	fmt.Println()
+}
+
+func displayFrequency(freq v4l2.FrequencyInfo, tuner v4l2.TunerInfo) {
+	typeName := v4l2.TunerTypes[freq.GetType()]
+	if typeName == "" {
+		typeName = fmt.Sprintf("Unknown (0x%x)", freq.GetType())
+	}
+
+	fmt.Printf("Tuner:      %d\n", freq.GetTuner())
+	fmt.Printf("Type:       %s\n", typeName)
+	fmt.Printf("Frequency:  %d", freq.GetFrequency())
+
+	if tuner.IsLowFreq() {
+		// Units are 1/16000 kHz (62.5 Hz)
+		fmt.Printf(" (%.3f MHz)\n", float64(freq.GetFrequency())/16000.0)
+	} else {
+		// Units are 1/16 MHz (62.5 kHz)
+		fmt.Printf(" (%.1f MHz)\n", float64(freq.GetFrequency())/16.0)
+	}
+}
+
+func displayBand(band v4l2.FrequencyBandInfo, tuner v4l2.TunerInfo) {
+	fmt.Printf("Band %d:\n", band.GetIndex())
+
+	// Display frequency range
+	rangeLow := band.GetRangeLow()
+	rangeHigh := band.GetRangeHigh()
+	if tuner.IsLowFreq() {
+		fmt.Printf("  Range:      %d - %d (%.3f - %.3f MHz)\n",
+			rangeLow, rangeHigh,
+			float64(rangeLow)/16000.0, float64(rangeHigh)/16000.0)
+	} else {
+		fmt.Printf("  Range:      %d - %d (%.1f - %.1f MHz)\n",
+			rangeLow, rangeHigh,
+			float64(rangeLow)/16.0, float64(rangeHigh)/16.0)
+	}
+
+	fmt.Printf("  Capability: 0x%08x\n", band.GetCapability())
+
+	// Display modulation
+	modulation := band.GetModulation()
+	fmt.Printf("  Modulation: 0x%x", modulation)
+	mods := []string{}
+	if modulation&v4l2.BandModulationFM != 0 {
+		mods = append(mods, "FM")
+	}
+	if modulation&v4l2.BandModulationAM != 0 {
+		mods = append(mods, "AM")
+	}
+	if modulation&v4l2.BandModulationVSB != 0 {
+		mods = append(mods, "VSB")
+	}
+	if len(mods) > 0 {
+		fmt.Print(" (")
+		for i, mod := range mods {
+			if i > 0 {
+				fmt.Print(", ")
+			}
+			fmt.Print(mod)
+		}
+		fmt.Print(")")
+	}
+	fmt.Println()
+	fmt.Println()
+}

--- a/test/tuner_modulator_test.go
+++ b/test/tuner_modulator_test.go
@@ -1,0 +1,405 @@
+// +build integration
+
+package test
+
+import (
+	"testing"
+
+	"github.com/vladimirvivien/go4vl/device"
+	"github.com/vladimirvivien/go4vl/v4l2"
+)
+
+// TestIntegration_TunerEnumeration tests tuner enumeration
+func TestIntegration_TunerEnumeration(t *testing.T) {
+	devPath := RequireV4L2Testing(t)
+
+	dev, err := device.Open(devPath)
+	if err != nil {
+		t.Fatalf("Failed to open device %s: %v", devPath, err)
+	}
+	defer dev.Close()
+
+	// Test GetAllTuners
+	tuners, err := dev.GetAllTuners()
+	if err != nil {
+		t.Logf("Device does not support tuner enumeration: %v", err)
+		return // Not all devices have tuners
+	}
+
+	if len(tuners) == 0 {
+		t.Log("Device reports no tuners")
+		return
+	}
+
+	t.Logf("Found %d tuner(s):", len(tuners))
+	for _, tuner := range tuners {
+		typeName := v4l2.TunerTypes[tuner.GetType()]
+		if typeName == "" {
+			typeName = "Unknown"
+		}
+		t.Logf("  [%d] %s", tuner.GetIndex(), tuner.GetName())
+		t.Logf("      Type: %s (0x%x)", typeName, tuner.GetType())
+		t.Logf("      Capability: 0x%x", tuner.GetCapability())
+		t.Logf("      Range: %d - %d", tuner.GetRangeLow(), tuner.GetRangeHigh())
+		t.Logf("      Signal: %d", tuner.GetSignal())
+		t.Logf("      AFC: %d", tuner.GetAFC())
+		t.Logf("      RxSubchans: 0x%x", tuner.GetRxSubchans())
+		t.Logf("      AudioMode: 0x%x", tuner.GetAudioMode())
+		t.Logf("      Stereo: %v", tuner.IsStereo())
+		t.Logf("      RDS: %v", tuner.HasRDS())
+		t.Logf("      LowFreq: %v", tuner.IsLowFreq())
+		t.Logf("      HwSeek: %v", tuner.SupportsHwSeek())
+		t.Logf("      FreqBands: %v", tuner.SupportsFreqBands())
+	}
+}
+
+// TestIntegration_TunerInfo tests getting specific tuner info
+func TestIntegration_TunerInfo(t *testing.T) {
+	devPath := RequireV4L2Testing(t)
+
+	dev, err := device.Open(devPath)
+	if err != nil {
+		t.Fatalf("Failed to open device: %v", err)
+	}
+	defer dev.Close()
+
+	// Get tuner info for index 0
+	info, err := dev.GetTunerInfo(0)
+	if err != nil {
+		t.Skip("Device does not support tuner info query")
+	}
+
+	// Verify the info is for the correct index
+	if info.GetIndex() != 0 {
+		t.Errorf("Expected index 0, got %d", info.GetIndex())
+	}
+
+	typeName := v4l2.TunerTypes[info.GetType()]
+	if typeName == "" {
+		typeName = "Unknown"
+	}
+
+	name := info.GetName()
+	t.Logf("Tuner 0: %s", name)
+	t.Logf("  Type: %s", typeName)
+	t.Logf("  Stereo: %v", info.IsStereo())
+	t.Logf("  RDS: %v", info.HasRDS())
+	t.Logf("  Signal: %d", info.GetSignal())
+}
+
+// TestIntegration_FrequencyGet tests getting tuner frequency
+func TestIntegration_FrequencyGet(t *testing.T) {
+	devPath := RequireV4L2Testing(t)
+
+	dev, err := device.Open(devPath)
+	if err != nil {
+		t.Fatalf("Failed to open device: %v", err)
+	}
+	defer dev.Close()
+
+	// First check if device has tuner
+	tuners, err := dev.GetAllTuners()
+	if err != nil || len(tuners) == 0 {
+		t.Skip("Device does not have tuners")
+	}
+
+	// Get frequency for first tuner
+	freq, err := dev.GetFrequency(0)
+	if err != nil {
+		t.Skip("Device does not support frequency query")
+	}
+
+	typeName := v4l2.TunerTypes[freq.GetType()]
+	if typeName == "" {
+		typeName = "Unknown"
+	}
+
+	t.Logf("Current frequency:")
+	t.Logf("  Tuner: %d", freq.GetTuner())
+	t.Logf("  Type: %s (0x%x)", typeName, freq.GetType())
+	t.Logf("  Frequency: %d", freq.GetFrequency())
+}
+
+// TestIntegration_FrequencySet tests setting tuner frequency
+func TestIntegration_FrequencySet(t *testing.T) {
+	devPath := RequireV4L2Testing(t)
+
+	dev, err := device.Open(devPath)
+	if err != nil {
+		t.Fatalf("Failed to open device: %v", err)
+	}
+	defer dev.Close()
+
+	// First check if device has tuner
+	tuners, err := dev.GetAllTuners()
+	if err != nil || len(tuners) == 0 {
+		t.Skip("Device does not have tuners")
+	}
+
+	tuner := tuners[0]
+
+	// Get current frequency first
+	originalFreq, err := dev.GetFrequency(0)
+	if err != nil {
+		t.Skip("Device does not support frequency operations")
+	}
+
+	// Try to set the same frequency (safe operation)
+	err = dev.SetFrequency(0, tuner.GetType(), originalFreq.GetFrequency())
+	if err != nil {
+		t.Logf("SetFrequency failed (expected for some devices): %v", err)
+		return
+	}
+
+	// Verify frequency was set
+	newFreq, err := dev.GetFrequency(0)
+	if err != nil {
+		t.Fatalf("Failed to get frequency after setting: %v", err)
+	}
+
+	if newFreq.GetFrequency() != originalFreq.GetFrequency() {
+		t.Logf("Warning: Frequency changed from %d to %d", originalFreq.GetFrequency(), newFreq.GetFrequency())
+	} else {
+		t.Logf("Frequency set successfully: %d", newFreq.GetFrequency())
+	}
+}
+
+// TestIntegration_FrequencyBands tests frequency band enumeration
+func TestIntegration_FrequencyBands(t *testing.T) {
+	devPath := RequireV4L2Testing(t)
+
+	dev, err := device.Open(devPath)
+	if err != nil {
+		t.Fatalf("Failed to open device: %v", err)
+	}
+	defer dev.Close()
+
+	// First check if device has tuner
+	tuners, err := dev.GetAllTuners()
+	if err != nil || len(tuners) == 0 {
+		t.Skip("Device does not have tuners")
+	}
+
+	// Check if tuner supports frequency bands
+	tuner := tuners[0]
+	if !tuner.SupportsFreqBands() {
+		t.Skip("Tuner does not support frequency bands enumeration")
+	}
+
+	// Get frequency bands
+	bands, err := dev.GetFrequencyBands(0, tuner.GetType())
+	if err != nil {
+		t.Logf("Failed to enumerate frequency bands: %v", err)
+		t.Skip("Frequency bands enumeration not supported")
+	}
+
+	if len(bands) == 0 {
+		t.Log("Tuner reports no frequency bands")
+		return
+	}
+
+	t.Logf("Found %d frequency band(s) for tuner 0:", len(bands))
+	for _, band := range bands {
+		t.Logf("  Band %d:", band.GetIndex())
+		t.Logf("    Range: %d - %d", band.GetRangeLow(), band.GetRangeHigh())
+		t.Logf("    Capability: 0x%x", band.GetCapability())
+		t.Logf("    Modulation: 0x%x", band.GetModulation())
+		t.Logf("    FM: %v", band.GetModulation()&v4l2.BandModulationFM != 0)
+		t.Logf("    AM: %v", band.GetModulation()&v4l2.BandModulationAM != 0)
+		t.Logf("    VSB: %v", band.GetModulation()&v4l2.BandModulationVSB != 0)
+	}
+}
+
+// TestIntegration_TunerSet tests setting tuner parameters
+func TestIntegration_TunerSet(t *testing.T) {
+	devPath := RequireV4L2Testing(t)
+
+	dev, err := device.Open(devPath)
+	if err != nil {
+		t.Fatalf("Failed to open device: %v", err)
+	}
+	defer dev.Close()
+
+	// First check if device has tuner
+	tuner, err := dev.GetTunerInfo(0)
+	if err != nil {
+		t.Skip("Device does not have tuners")
+	}
+
+	// Try to set tuner (with same parameters - safe operation)
+	err = dev.SetTuner(tuner)
+	if err != nil {
+		t.Logf("SetTuner failed (expected for some devices): %v", err)
+		return
+	}
+
+	t.Log("SetTuner succeeded")
+}
+
+// TestIntegration_ModulatorEnumeration tests modulator enumeration
+func TestIntegration_ModulatorEnumeration(t *testing.T) {
+	devPath := RequireV4L2Testing(t)
+
+	dev, err := device.Open(devPath)
+	if err != nil {
+		t.Fatalf("Failed to open device %s: %v", devPath, err)
+	}
+	defer dev.Close()
+
+	// Test GetAllModulators
+	modulators, err := dev.GetAllModulators()
+	if err != nil {
+		t.Logf("Device does not support modulator enumeration: %v", err)
+		return // Not all devices have modulators
+	}
+
+	if len(modulators) == 0 {
+		t.Log("Device reports no modulators")
+		return
+	}
+
+	t.Logf("Found %d modulator(s):", len(modulators))
+	for _, mod := range modulators {
+		typeName := v4l2.TunerTypes[mod.GetType()]
+		if typeName == "" {
+			typeName = "Unknown"
+		}
+		t.Logf("  [%d] %s", mod.GetIndex(), mod.GetName())
+		t.Logf("      Type: %s (0x%x)", typeName, mod.GetType())
+		t.Logf("      Capability: 0x%x", mod.GetCapability())
+		t.Logf("      Range: %d - %d", mod.GetRangeLow(), mod.GetRangeHigh())
+		t.Logf("      TxSubchans: 0x%x", mod.GetTxSubchans())
+		t.Logf("      Stereo: %v", mod.IsStereo())
+		t.Logf("      RDS: %v", mod.HasRDS())
+		t.Logf("      LowFreq: %v", mod.IsLowFreq())
+		t.Logf("      FreqBands: %v", mod.SupportsFreqBands())
+	}
+}
+
+// TestIntegration_ModulatorInfo tests getting specific modulator info
+func TestIntegration_ModulatorInfo(t *testing.T) {
+	devPath := RequireV4L2Testing(t)
+
+	dev, err := device.Open(devPath)
+	if err != nil {
+		t.Fatalf("Failed to open device: %v", err)
+	}
+	defer dev.Close()
+
+	// Get modulator info for index 0
+	info, err := dev.GetModulatorInfo(0)
+	if err != nil {
+		t.Skip("Device does not support modulator info query")
+	}
+
+	// Verify the info is for the correct index
+	if info.GetIndex() != 0 {
+		t.Errorf("Expected index 0, got %d", info.GetIndex())
+	}
+
+	typeName := v4l2.TunerTypes[info.GetType()]
+	if typeName == "" {
+		typeName = "Unknown"
+	}
+
+	name := info.GetName()
+	t.Logf("Modulator 0: %s", name)
+	t.Logf("  Type: %s", typeName)
+	t.Logf("  Stereo: %v", info.IsStereo())
+	t.Logf("  RDS: %v", info.HasRDS())
+}
+
+// TestIntegration_ModulatorSet tests setting modulator parameters
+func TestIntegration_ModulatorSet(t *testing.T) {
+	devPath := RequireV4L2Testing(t)
+
+	dev, err := device.Open(devPath)
+	if err != nil {
+		t.Fatalf("Failed to open device: %v", err)
+	}
+	defer dev.Close()
+
+	// First check if device has modulator
+	mod, err := dev.GetModulatorInfo(0)
+	if err != nil {
+		t.Skip("Device does not have modulators")
+	}
+
+	// Try to set modulator (with same parameters - safe operation)
+	err = dev.SetModulator(mod)
+	if err != nil {
+		t.Logf("SetModulator failed (expected for some devices): %v", err)
+		return
+	}
+
+	t.Log("SetModulator succeeded")
+}
+
+// TestIntegration_TunerModulator_APIParity tests API parity between tuner and modulator
+func TestIntegration_TunerModulator_APIParity(t *testing.T) {
+	devPath := RequireV4L2Testing(t)
+
+	dev, err := device.Open(devPath)
+	if err != nil {
+		t.Fatalf("Failed to open device: %v", err)
+	}
+	defer dev.Close()
+
+	t.Log("Verifying API parity between Tuner and Modulator")
+
+	// Both should have GetAll methods
+	tuners, tunerErr := dev.GetAllTuners()
+	modulators, modErr := dev.GetAllModulators()
+
+	if tunerErr != nil {
+		t.Logf("  GetAllTuners: not supported")
+	} else {
+		t.Logf("  GetAllTuners: %d tuner(s)", len(tuners))
+	}
+
+	if modErr != nil {
+		t.Logf("  GetAllModulators: not supported")
+	} else {
+		t.Logf("  GetAllModulators: %d modulator(s)", len(modulators))
+	}
+
+	// Both should have GetInfo methods
+	if tunerErr == nil && len(tuners) > 0 {
+		_, err := dev.GetTunerInfo(0)
+		if err != nil {
+			t.Logf("  GetTunerInfo: failed - %v", err)
+		} else {
+			t.Logf("  GetTunerInfo: success")
+		}
+	}
+
+	if modErr == nil && len(modulators) > 0 {
+		_, err := dev.GetModulatorInfo(0)
+		if err != nil {
+			t.Logf("  GetModulatorInfo: failed - %v", err)
+		} else {
+			t.Logf("  GetModulatorInfo: success")
+		}
+	}
+
+	// Both should support frequency operations
+	if tunerErr == nil && len(tuners) > 0 {
+		_, err := dev.GetFrequency(0)
+		if err != nil {
+			t.Logf("  GetFrequency (tuner): not supported")
+		} else {
+			t.Logf("  GetFrequency (tuner): success")
+		}
+
+		if tuners[0].SupportsFreqBands() {
+			bands, err := dev.GetFrequencyBands(0, tuners[0].GetType())
+			if err != nil {
+				t.Logf("  GetFrequencyBands: failed - %v", err)
+			} else {
+				t.Logf("  GetFrequencyBands: %d band(s)", len(bands))
+			}
+		}
+	}
+
+	t.Log("API parity check complete")
+}

--- a/v4l2/tuner_info.go
+++ b/v4l2/tuner_info.go
@@ -1,0 +1,539 @@
+package v4l2
+
+// tuner_info.go provides tuner and modulator enumeration and control.
+//
+// Tuners and modulators are used for radio and TV devices to tune to specific frequencies.
+// A tuner receives signals (e.g., FM/AM radio, analog/digital TV, SDR), while a modulator
+// transmits signals (e.g., RF modulator for video output).
+//
+// The V4L2 API provides the following operations:
+//   - Enumerate and query tuner/modulator properties
+//   - Get/set tuner parameters (audio mode, frequency)
+//   - Get/set modulator parameters (frequency, transmission subchannel)
+//   - Query signal strength and AFC (Automatic Frequency Control)
+//   - Enumerate frequency bands
+//
+// See: https://linuxtv.org/downloads/v4l-dvb-apis/userspace-api/v4l/vidioc-g-tuner.html
+// See: https://linuxtv.org/downloads/v4l-dvb-apis/userspace-api/v4l/vidioc-g-modulator.html
+// See: https://linuxtv.org/downloads/v4l-dvb-apis/userspace-api/v4l/vidioc-g-frequency.html
+
+// #include <linux/videodev2.h>
+import "C"
+
+import (
+	"fmt"
+	"unsafe"
+
+	sys "golang.org/x/sys/unix"
+)
+
+// TunerType represents the type of tuner/modulator
+type TunerType = uint32
+
+const (
+	TunerTypeRadio     TunerType = C.V4L2_TUNER_RADIO      // Radio tuner (AM/FM)
+	TunerTypeAnalogTV  TunerType = C.V4L2_TUNER_ANALOG_TV  // Analog TV tuner
+	TunerTypeDigitalTV TunerType = C.V4L2_TUNER_DIGITAL_TV // Digital TV tuner
+	TunerTypeSDR       TunerType = C.V4L2_TUNER_SDR        // Software Defined Radio
+	TunerTypeRF        TunerType = C.V4L2_TUNER_RF         // RF tuner
+)
+
+// TunerTypes maps tuner type constants to human-readable strings
+var TunerTypes = map[TunerType]string{
+	TunerTypeRadio:     "Radio",
+	TunerTypeAnalogTV:  "Analog TV",
+	TunerTypeDigitalTV: "Digital TV",
+	TunerTypeSDR:       "SDR",
+	TunerTypeRF:        "RF",
+}
+
+// TunerCapability represents tuner/modulator capability flags
+type TunerCapability = uint32
+
+const (
+	TunerCapLow            TunerCapability = C.V4L2_TUNER_CAP_LOW             // Freq in 1/16 kHz units (vs 1/16 MHz)
+	TunerCapNorm           TunerCapability = C.V4L2_TUNER_CAP_NORM            // Multi-standard tuner
+	TunerCapHwSeekBounded  TunerCapability = C.V4L2_TUNER_CAP_HWSEEK_BOUNDED  // Hardware seek bounded
+	TunerCapHwSeekWrap     TunerCapability = C.V4L2_TUNER_CAP_HWSEEK_WRAP     // Hardware seek wraps around
+	TunerCapStereo         TunerCapability = C.V4L2_TUNER_CAP_STEREO          // Stereo reception/transmission
+	TunerCapLang2          TunerCapability = C.V4L2_TUNER_CAP_LANG2           // Bilingual mode (LANG2/SAP)
+	TunerCapSAP            TunerCapability = C.V4L2_TUNER_CAP_SAP             // SAP (Second Audio Program)
+	TunerCapLang1          TunerCapability = C.V4L2_TUNER_CAP_LANG1           // Primary language
+	TunerCapRDS            TunerCapability = C.V4L2_TUNER_CAP_RDS             // Radio Data System
+	TunerCapRDSBlockIO     TunerCapability = C.V4L2_TUNER_CAP_RDS_BLOCK_IO    // RDS block I/O interface
+	TunerCapRDSControls    TunerCapability = C.V4L2_TUNER_CAP_RDS_CONTROLS    // RDS controls available
+	TunerCapFreqBands      TunerCapability = C.V4L2_TUNER_CAP_FREQ_BANDS      // Multiple frequency bands
+	TunerCapHwSeekProgLim  TunerCapability = C.V4L2_TUNER_CAP_HWSEEK_PROG_LIM // Programmable hardware seek limits
+	TunerCap1Hz            TunerCapability = C.V4L2_TUNER_CAP_1HZ             // 1 Hz frequency step
+)
+
+// TunerRxSubchannel represents received audio subchannels
+type TunerRxSubchannel = uint32
+
+const (
+	TunerSubMono   TunerRxSubchannel = C.V4L2_TUNER_SUB_MONO   // Mono audio detected
+	TunerSubStereo TunerRxSubchannel = C.V4L2_TUNER_SUB_STEREO // Stereo audio detected
+	TunerSubLang2  TunerRxSubchannel = C.V4L2_TUNER_SUB_LANG2  // LANG2/SAP detected
+	TunerSubSAP    TunerRxSubchannel = C.V4L2_TUNER_SUB_SAP    // SAP detected
+	TunerSubLang1  TunerRxSubchannel = C.V4L2_TUNER_SUB_LANG1  // LANG1 detected
+	TunerSubRDS    TunerRxSubchannel = C.V4L2_TUNER_SUB_RDS    // RDS data available
+)
+
+// TunerAudioMode represents the audio mode to select
+type TunerAudioMode = uint32
+
+const (
+	TunerModeMono       TunerAudioMode = C.V4L2_TUNER_MODE_MONO        // Mono audio
+	TunerModeStereo     TunerAudioMode = C.V4L2_TUNER_MODE_STEREO      // Stereo audio
+	TunerModeLang2      TunerAudioMode = C.V4L2_TUNER_MODE_LANG2       // LANG2/SAP
+	TunerModeSAP        TunerAudioMode = C.V4L2_TUNER_MODE_SAP         // SAP (same as LANG2)
+	TunerModeLang1      TunerAudioMode = C.V4L2_TUNER_MODE_LANG1       // LANG1
+	TunerModeLang1Lang2 TunerAudioMode = C.V4L2_TUNER_MODE_LANG1_LANG2 // LANG1 + LANG2
+)
+
+// TunerAudioModes maps audio mode constants to human-readable strings
+var TunerAudioModes = map[TunerAudioMode]string{
+	TunerModeMono:       "Mono",
+	TunerModeStereo:     "Stereo",
+	TunerModeLang2:      "Lang2/SAP",
+	TunerModeLang1:      "Lang1",
+	TunerModeLang1Lang2: "Lang1+Lang2",
+}
+
+// BandModulation represents frequency band modulation types
+type BandModulation = uint32
+
+const (
+	BandModulationVSB BandModulation = C.V4L2_BAND_MODULATION_VSB // Vestigial Sideband
+	BandModulationFM  BandModulation = C.V4L2_BAND_MODULATION_FM  // Frequency Modulation
+	BandModulationAM  BandModulation = C.V4L2_BAND_MODULATION_AM  // Amplitude Modulation
+)
+
+// TunerInfo wraps v4l2_tuner structure
+// https://elixir.bootlin.com/linux/latest/source/include/uapi/linux/videodev2.h
+// https://linuxtv.org/downloads/v4l-dvb-apis/userspace-api/v4l/vidioc-g-tuner.html
+type TunerInfo struct {
+	v4l2Tuner C.struct_v4l2_tuner
+}
+
+// Accessor methods for TunerInfo
+
+func (t TunerInfo) GetIndex() uint32 {
+	return uint32(t.v4l2Tuner.index)
+}
+
+func (t TunerInfo) GetName() string {
+	return C.GoString((*C.char)(unsafe.Pointer(&t.v4l2Tuner.name[0])))
+}
+
+func (t TunerInfo) GetType() TunerType {
+	return TunerType(t.v4l2Tuner._type)
+}
+
+func (t TunerInfo) GetCapability() TunerCapability {
+	return TunerCapability(t.v4l2Tuner.capability)
+}
+
+func (t TunerInfo) GetRangeLow() uint32 {
+	return uint32(t.v4l2Tuner.rangelow)
+}
+
+func (t TunerInfo) GetRangeHigh() uint32 {
+	return uint32(t.v4l2Tuner.rangehigh)
+}
+
+func (t TunerInfo) GetRxSubchans() TunerRxSubchannel {
+	return TunerRxSubchannel(t.v4l2Tuner.rxsubchans)
+}
+
+func (t TunerInfo) GetAudioMode() TunerAudioMode {
+	return TunerAudioMode(t.v4l2Tuner.audmode)
+}
+
+func (t TunerInfo) GetSignal() int32 {
+	return int32(t.v4l2Tuner.signal)
+}
+
+func (t TunerInfo) GetAFC() int32 {
+	return int32(t.v4l2Tuner.afc)
+}
+
+// Capability check helper methods for TunerInfo
+
+func (t TunerInfo) HasCapability(cap TunerCapability) bool {
+	return (t.GetCapability() & cap) != 0
+}
+
+func (t TunerInfo) IsLowFreq() bool {
+	return t.HasCapability(TunerCapLow)
+}
+
+func (t TunerInfo) IsStereo() bool {
+	return t.HasCapability(TunerCapStereo)
+}
+
+func (t TunerInfo) HasRDS() bool {
+	return t.HasCapability(TunerCapRDS)
+}
+
+func (t TunerInfo) SupportsHwSeek() bool {
+	return t.HasCapability(TunerCapHwSeekBounded) || t.HasCapability(TunerCapHwSeekWrap)
+}
+
+func (t TunerInfo) SupportsFreqBands() bool {
+	return t.HasCapability(TunerCapFreqBands)
+}
+
+// ModulatorInfo wraps v4l2_modulator structure
+// https://elixir.bootlin.com/linux/latest/source/include/uapi/linux/videodev2.h
+// https://linuxtv.org/downloads/v4l-dvb-apis/userspace-api/v4l/vidioc-g-modulator.html
+type ModulatorInfo struct {
+	v4l2Modulator C.struct_v4l2_modulator
+}
+
+// Accessor methods for ModulatorInfo
+
+func (m ModulatorInfo) GetIndex() uint32 {
+	return uint32(m.v4l2Modulator.index)
+}
+
+func (m ModulatorInfo) GetName() string {
+	return C.GoString((*C.char)(unsafe.Pointer(&m.v4l2Modulator.name[0])))
+}
+
+func (m ModulatorInfo) GetCapability() TunerCapability {
+	return TunerCapability(m.v4l2Modulator.capability)
+}
+
+func (m ModulatorInfo) GetRangeLow() uint32 {
+	return uint32(m.v4l2Modulator.rangelow)
+}
+
+func (m ModulatorInfo) GetRangeHigh() uint32 {
+	return uint32(m.v4l2Modulator.rangehigh)
+}
+
+func (m ModulatorInfo) GetTxSubchans() uint32 {
+	return uint32(m.v4l2Modulator.txsubchans)
+}
+
+func (m ModulatorInfo) GetType() TunerType {
+	return TunerType(m.v4l2Modulator._type)
+}
+
+// Capability check helper methods for ModulatorInfo
+
+func (m ModulatorInfo) HasCapability(cap TunerCapability) bool {
+	return (m.GetCapability() & cap) != 0
+}
+
+func (m ModulatorInfo) IsLowFreq() bool {
+	return m.HasCapability(TunerCapLow)
+}
+
+func (m ModulatorInfo) IsStereo() bool {
+	return m.HasCapability(TunerCapStereo)
+}
+
+func (m ModulatorInfo) HasRDS() bool {
+	return m.HasCapability(TunerCapRDS)
+}
+
+func (m ModulatorInfo) SupportsFreqBands() bool {
+	return m.HasCapability(TunerCapFreqBands)
+}
+
+// FrequencyInfo wraps v4l2_frequency structure
+// https://elixir.bootlin.com/linux/latest/source/include/uapi/linux/videodev2.h
+// https://linuxtv.org/downloads/v4l-dvb-apis/userspace-api/v4l/vidioc-g-frequency.html
+type FrequencyInfo struct {
+	v4l2Frequency C.struct_v4l2_frequency
+}
+
+// Accessor methods for FrequencyInfo
+
+func (f FrequencyInfo) GetTuner() uint32 {
+	return uint32(f.v4l2Frequency.tuner)
+}
+
+func (f FrequencyInfo) GetType() TunerType {
+	return TunerType(f.v4l2Frequency._type)
+}
+
+func (f FrequencyInfo) GetFrequency() uint32 {
+	return uint32(f.v4l2Frequency.frequency)
+}
+
+// FrequencyBandInfo wraps v4l2_frequency_band structure
+// https://elixir.bootlin.com/linux/latest/source/include/uapi/linux/videodev2.h
+// https://linuxtv.org/downloads/v4l-dvb-apis/userspace-api/v4l/vidioc-enum-freq-bands.html
+type FrequencyBandInfo struct {
+	v4l2FreqBand C.struct_v4l2_frequency_band
+}
+
+// Accessor methods for FrequencyBandInfo
+
+func (fb FrequencyBandInfo) GetTuner() uint32 {
+	return uint32(fb.v4l2FreqBand.tuner)
+}
+
+func (fb FrequencyBandInfo) GetType() TunerType {
+	return TunerType(fb.v4l2FreqBand._type)
+}
+
+func (fb FrequencyBandInfo) GetIndex() uint32 {
+	return uint32(fb.v4l2FreqBand.index)
+}
+
+func (fb FrequencyBandInfo) GetCapability() TunerCapability {
+	return TunerCapability(fb.v4l2FreqBand.capability)
+}
+
+func (fb FrequencyBandInfo) GetRangeLow() uint32 {
+	return uint32(fb.v4l2FreqBand.rangelow)
+}
+
+func (fb FrequencyBandInfo) GetRangeHigh() uint32 {
+	return uint32(fb.v4l2FreqBand.rangehigh)
+}
+
+func (fb FrequencyBandInfo) GetModulation() BandModulation {
+	return BandModulation(fb.v4l2FreqBand.modulation)
+}
+
+func (fb FrequencyBandInfo) HasCapability(cap TunerCapability) bool {
+	return (fb.GetCapability() & cap) != 0
+}
+
+// ============================================================================
+// Tuner Operations
+// ============================================================================
+
+// GetTunerInfo gets information about a specific tuner by index
+// Implements VIDIOC_G_TUNER ioctl
+//
+// Example:
+//
+//	tuner, err := v4l2.GetTunerInfo(fd, 0)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	fmt.Printf("Tuner: %s, Type: %s\n", tuner.GetName(), v4l2.TunerTypes[tuner.GetType()])
+func GetTunerInfo(fd uintptr, index uint32) (TunerInfo, error) {
+	var tuner C.struct_v4l2_tuner
+	tuner.index = C.uint(index)
+
+	if err := send(fd, C.VIDIOC_G_TUNER, uintptr(unsafe.Pointer(&tuner))); err != nil {
+		return TunerInfo{}, fmt.Errorf("v4l2: VIDIOC_G_TUNER failed for index %d: %w", index, err)
+	}
+
+	return TunerInfo{v4l2Tuner: tuner}, nil
+}
+
+// SetTuner sets tuner parameters (audio mode)
+// Implements VIDIOC_S_TUNER ioctl
+//
+// Example:
+//
+//	tuner, _ := v4l2.GetTunerInfo(fd, 0)
+//	tuner.v4l2Tuner.audmode = C.V4L2_TUNER_MODE_STEREO
+//	err := v4l2.SetTuner(fd, tuner)
+func SetTuner(fd uintptr, tuner TunerInfo) error {
+	if err := send(fd, C.VIDIOC_S_TUNER, uintptr(unsafe.Pointer(&tuner.v4l2Tuner))); err != nil {
+		return fmt.Errorf("v4l2: VIDIOC_S_TUNER failed: %w", err)
+	}
+	return nil
+}
+
+// GetAllTuners enumerates all tuners available on the device
+// Returns a slice of TunerInfo or an error
+//
+// Example:
+//
+//	tuners, err := v4l2.GetAllTuners(fd)
+//	for _, tuner := range tuners {
+//	    fmt.Printf("Tuner %d: %s\n", tuner.GetIndex(), tuner.GetName())
+//	}
+func GetAllTuners(fd uintptr) ([]TunerInfo, error) {
+	var result []TunerInfo
+
+	for i := uint32(0); i < 256; i++ {
+		tuner, err := GetTunerInfo(fd, i)
+		if err != nil {
+			// EINVAL indicates no more tuners
+			if errno, ok := err.(sys.Errno); ok && errno == sys.EINVAL && len(result) > 0 {
+				break
+			}
+			return result, err
+		}
+		result = append(result, tuner)
+	}
+
+	return result, nil
+}
+
+// ============================================================================
+// Modulator Operations
+// ============================================================================
+
+// GetModulatorInfo gets information about a specific modulator by index
+// Implements VIDIOC_G_MODULATOR ioctl
+//
+// Example:
+//
+//	mod, err := v4l2.GetModulatorInfo(fd, 0)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	fmt.Printf("Modulator: %s\n", mod.GetName())
+func GetModulatorInfo(fd uintptr, index uint32) (ModulatorInfo, error) {
+	var modulator C.struct_v4l2_modulator
+	modulator.index = C.uint(index)
+
+	if err := send(fd, C.VIDIOC_G_MODULATOR, uintptr(unsafe.Pointer(&modulator))); err != nil {
+		return ModulatorInfo{}, fmt.Errorf("v4l2: VIDIOC_G_MODULATOR failed for index %d: %w", index, err)
+	}
+
+	return ModulatorInfo{v4l2Modulator: modulator}, nil
+}
+
+// SetModulator sets modulator parameters (transmission subchannels)
+// Implements VIDIOC_S_MODULATOR ioctl
+//
+// Example:
+//
+//	mod, _ := v4l2.GetModulatorInfo(fd, 0)
+//	mod.v4l2Modulator.txsubchans = C.V4L2_TUNER_SUB_STEREO
+//	err := v4l2.SetModulator(fd, mod)
+func SetModulator(fd uintptr, modulator ModulatorInfo) error {
+	if err := send(fd, C.VIDIOC_S_MODULATOR, uintptr(unsafe.Pointer(&modulator.v4l2Modulator))); err != nil {
+		return fmt.Errorf("v4l2: VIDIOC_S_MODULATOR failed: %w", err)
+	}
+	return nil
+}
+
+// GetAllModulators enumerates all modulators available on the device
+// Returns a slice of ModulatorInfo or an error
+//
+// Example:
+//
+//	modulators, err := v4l2.GetAllModulators(fd)
+//	for _, mod := range modulators {
+//	    fmt.Printf("Modulator %d: %s\n", mod.GetIndex(), mod.GetName())
+//	}
+func GetAllModulators(fd uintptr) ([]ModulatorInfo, error) {
+	var result []ModulatorInfo
+
+	for i := uint32(0); i < 256; i++ {
+		modulator, err := GetModulatorInfo(fd, i)
+		if err != nil {
+			// EINVAL indicates no more modulators
+			if errno, ok := err.(sys.Errno); ok && errno == sys.EINVAL && len(result) > 0 {
+				break
+			}
+			return result, err
+		}
+		result = append(result, modulator)
+	}
+
+	return result, nil
+}
+
+// ============================================================================
+// Frequency Operations
+// ============================================================================
+
+// GetFrequency gets the current tuner/modulator frequency
+// Implements VIDIOC_G_FREQUENCY ioctl
+//
+// Example:
+//
+//	freq, err := v4l2.GetFrequency(fd, 0)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	fmt.Printf("Current frequency: %d\n", freq.GetFrequency())
+func GetFrequency(fd uintptr, tunerIndex uint32) (FrequencyInfo, error) {
+	var frequency C.struct_v4l2_frequency
+	frequency.tuner = C.uint(tunerIndex)
+
+	if err := send(fd, C.VIDIOC_G_FREQUENCY, uintptr(unsafe.Pointer(&frequency))); err != nil {
+		return FrequencyInfo{}, fmt.Errorf("v4l2: VIDIOC_G_FREQUENCY failed for tuner %d: %w", tunerIndex, err)
+	}
+
+	return FrequencyInfo{v4l2Frequency: frequency}, nil
+}
+
+// SetFrequency sets the tuner/modulator frequency
+// Implements VIDIOC_S_FREQUENCY ioctl
+//
+// Example:
+//
+//	// Set FM radio to 100.5 MHz (assuming 62.5 Hz units, which is 1/16000 kHz)
+//	// 100.5 MHz = 100500 kHz = 100500 * 16 units = 1608000 units
+//	err := v4l2.SetFrequency(fd, 0, v4l2.TunerTypeRadio, 1608000)
+func SetFrequency(fd uintptr, tunerIndex uint32, tunerType TunerType, frequency uint32) error {
+	var freq C.struct_v4l2_frequency
+	freq.tuner = C.uint(tunerIndex)
+	freq._type = C.uint(tunerType)
+	freq.frequency = C.uint(frequency)
+
+	if err := send(fd, C.VIDIOC_S_FREQUENCY, uintptr(unsafe.Pointer(&freq))); err != nil {
+		return fmt.Errorf("v4l2: VIDIOC_S_FREQUENCY failed: %w", err)
+	}
+	return nil
+}
+
+// ============================================================================
+// Frequency Band Operations
+// ============================================================================
+
+// GetFrequencyBandInfo gets information about a specific frequency band
+// Implements VIDIOC_ENUM_FREQ_BANDS ioctl
+//
+// Example:
+//
+//	band, err := v4l2.GetFrequencyBandInfo(fd, 0, v4l2.TunerTypeRadio, 0)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	fmt.Printf("Band: %d - %d\n", band.GetRangeLow(), band.GetRangeHigh())
+func GetFrequencyBandInfo(fd uintptr, tunerIndex uint32, tunerType TunerType, bandIndex uint32) (FrequencyBandInfo, error) {
+	var band C.struct_v4l2_frequency_band
+	band.tuner = C.uint(tunerIndex)
+	band._type = C.uint(tunerType)
+	band.index = C.uint(bandIndex)
+
+	if err := send(fd, C.VIDIOC_ENUM_FREQ_BANDS, uintptr(unsafe.Pointer(&band))); err != nil {
+		return FrequencyBandInfo{}, fmt.Errorf("v4l2: VIDIOC_ENUM_FREQ_BANDS failed for tuner %d band %d: %w", tunerIndex, bandIndex, err)
+	}
+
+	return FrequencyBandInfo{v4l2FreqBand: band}, nil
+}
+
+// GetAllFrequencyBands enumerates all frequency bands for a specific tuner
+// Returns a slice of FrequencyBandInfo or an error
+//
+// Example:
+//
+//	bands, err := v4l2.GetAllFrequencyBands(fd, 0, v4l2.TunerTypeRadio)
+//	for _, band := range bands {
+//	    fmt.Printf("Band %d: %d - %d\n", band.GetIndex(), band.GetRangeLow(), band.GetRangeHigh())
+//	}
+func GetAllFrequencyBands(fd uintptr, tunerIndex uint32, tunerType TunerType) ([]FrequencyBandInfo, error) {
+	var result []FrequencyBandInfo
+
+	for i := uint32(0); i < 256; i++ {
+		band, err := GetFrequencyBandInfo(fd, tunerIndex, tunerType, i)
+		if err != nil {
+			// EINVAL indicates no more bands
+			if errno, ok := err.(sys.Errno); ok && errno == sys.EINVAL && len(result) > 0 {
+				break
+			}
+			return result, err
+		}
+		result = append(result, band)
+	}
+
+	return result, nil
+}

--- a/v4l2/tuner_info_test.go
+++ b/v4l2/tuner_info_test.go
@@ -1,0 +1,373 @@
+package v4l2
+
+import (
+	"testing"
+)
+
+// TestTunerType_Constants verifies tuner type constants are defined
+func TestTunerType_Constants(t *testing.T) {
+	tests := []struct {
+		name      string
+		tunerType TunerType
+	}{
+		{"TunerTypeRadio", TunerTypeRadio},
+		{"TunerTypeAnalogTV", TunerTypeAnalogTV},
+		{"TunerTypeDigitalTV", TunerTypeDigitalTV},
+		{"TunerTypeSDR", TunerTypeSDR},
+		{"TunerTypeRF", TunerTypeRF},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.tunerType == 0 {
+				t.Errorf("%s should not be zero", tt.name)
+			}
+		})
+	}
+}
+
+// TestTunerTypes_MapComplete verifies TunerTypes map contains all tuner types
+func TestTunerTypes_MapComplete(t *testing.T) {
+	expectedTypes := []TunerType{
+		TunerTypeRadio,
+		TunerTypeAnalogTV,
+		TunerTypeDigitalTV,
+		TunerTypeSDR,
+		TunerTypeRF,
+	}
+
+	for _, tunerType := range expectedTypes {
+		if name, ok := TunerTypes[tunerType]; !ok {
+			t.Errorf("TunerTypes map missing entry for type %d", tunerType)
+		} else if name == "" {
+			t.Errorf("TunerTypes map has empty name for type %d", tunerType)
+		}
+	}
+}
+
+// TestTunerCapability_Constants verifies tuner capability constants are defined
+func TestTunerCapability_Constants(t *testing.T) {
+	tests := []struct {
+		name       string
+		capability TunerCapability
+	}{
+		{"TunerCapLow", TunerCapLow},
+		{"TunerCapNorm", TunerCapNorm},
+		{"TunerCapHwSeekBounded", TunerCapHwSeekBounded},
+		{"TunerCapHwSeekWrap", TunerCapHwSeekWrap},
+		{"TunerCapStereo", TunerCapStereo},
+		{"TunerCapLang2", TunerCapLang2},
+		{"TunerCapSAP", TunerCapSAP},
+		{"TunerCapLang1", TunerCapLang1},
+		{"TunerCapRDS", TunerCapRDS},
+		{"TunerCapRDSBlockIO", TunerCapRDSBlockIO},
+		{"TunerCapRDSControls", TunerCapRDSControls},
+		{"TunerCapFreqBands", TunerCapFreqBands},
+		{"TunerCapHwSeekProgLim", TunerCapHwSeekProgLim},
+		{"TunerCap1Hz", TunerCap1Hz},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.capability == 0 {
+				t.Errorf("%s should not be zero", tt.name)
+			}
+		})
+	}
+}
+
+// TestTunerRxSubchannel_Constants verifies received subchannel constants
+func TestTunerRxSubchannel_Constants(t *testing.T) {
+	tests := []struct {
+		name        string
+		subchannel  TunerRxSubchannel
+		expectZero  bool
+	}{
+		{"TunerSubMono", TunerSubMono, true},  // Mono can be 0x0001
+		{"TunerSubStereo", TunerSubStereo, false},
+		{"TunerSubLang2", TunerSubLang2, false},
+		{"TunerSubSAP", TunerSubSAP, false},
+		{"TunerSubLang1", TunerSubLang1, false},
+		{"TunerSubRDS", TunerSubRDS, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !tt.expectZero && tt.subchannel == 0 {
+				t.Errorf("%s should not be zero", tt.name)
+			}
+		})
+	}
+}
+
+// TestTunerAudioMode_Constants verifies audio mode constants
+func TestTunerAudioMode_Constants(t *testing.T) {
+	tests := []struct {
+		name       string
+		mode       TunerAudioMode
+		expectZero bool
+	}{
+		{"TunerModeMono", TunerModeMono, true}, // Mono is 0x0000
+		{"TunerModeStereo", TunerModeStereo, false},
+		{"TunerModeLang2", TunerModeLang2, false},
+		{"TunerModeSAP", TunerModeSAP, false},
+		{"TunerModeLang1", TunerModeLang1, false},
+		{"TunerModeLang1Lang2", TunerModeLang1Lang2, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !tt.expectZero && tt.mode == 0 {
+				t.Errorf("%s should not be zero", tt.name)
+			}
+		})
+	}
+}
+
+// TestTunerAudioModes_MapComplete verifies TunerAudioModes map contains all modes
+func TestTunerAudioModes_MapComplete(t *testing.T) {
+	expectedModes := []TunerAudioMode{
+		TunerModeMono,
+		TunerModeStereo,
+		TunerModeLang2,
+		TunerModeLang1,
+		TunerModeLang1Lang2,
+	}
+
+	for _, mode := range expectedModes {
+		if name, ok := TunerAudioModes[mode]; !ok {
+			t.Errorf("TunerAudioModes map missing entry for mode %d", mode)
+		} else if name == "" {
+			t.Errorf("TunerAudioModes map has empty name for mode %d", mode)
+		}
+	}
+}
+
+// TestBandModulation_Constants verifies band modulation constants
+func TestBandModulation_Constants(t *testing.T) {
+	tests := []struct {
+		name       string
+		modulation BandModulation
+	}{
+		{"BandModulationVSB", BandModulationVSB},
+		{"BandModulationFM", BandModulationFM},
+		{"BandModulationAM", BandModulationAM},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.modulation == 0 {
+				t.Errorf("%s should not be zero", tt.name)
+			}
+		})
+	}
+}
+
+// TestTunerInfo_Accessors tests TunerInfo accessor methods
+func TestTunerInfo_Accessors(t *testing.T) {
+	// Note: This test verifies the accessor methods exist and return correct types
+	// Actual functionality requires a real device or mock
+	var info TunerInfo
+
+	// Test that methods don't panic and return expected types
+	_ = info.GetIndex()
+	_ = info.GetName()
+	_ = info.GetType()
+	_ = info.GetCapability()
+	_ = info.GetRangeLow()
+	_ = info.GetRangeHigh()
+	_ = info.GetRxSubchans()
+	_ = info.GetAudioMode()
+	_ = info.GetSignal()
+	_ = info.GetAFC()
+
+	// All methods returned without panic - success
+}
+
+// TestTunerInfo_CapabilityHelpers tests TunerInfo capability helper methods
+func TestTunerInfo_CapabilityHelpers(t *testing.T) {
+	var info TunerInfo
+
+	// Test that helper methods don't panic
+	_ = info.HasCapability(TunerCapStereo)
+	_ = info.IsLowFreq()
+	_ = info.IsStereo()
+	_ = info.HasRDS()
+	_ = info.SupportsHwSeek()
+	_ = info.SupportsFreqBands()
+
+	// All methods returned without panic - success
+}
+
+// TestTunerInfo_GetName tests name extraction from TunerInfo
+func TestTunerInfo_GetName(t *testing.T) {
+	// This test verifies the GetName method works correctly
+	// The actual C struct initialization would require CGO setup
+	var info TunerInfo
+	name := info.GetName()
+
+	// Empty C string should return empty Go string
+	if name != "" {
+		t.Logf("GetName() returned: %q (expected empty for uninitialized struct)", name)
+	}
+}
+
+// TestTunerInfo_HasCapability tests capability checking
+func TestTunerInfo_HasCapability(t *testing.T) {
+	// This test verifies the HasCapability logic
+	var info TunerInfo
+
+	// Zero capability means no capabilities
+	if info.HasCapability(TunerCapStereo) {
+		t.Error("Uninitialized TunerInfo should not have TunerCapStereo")
+	}
+
+	if info.HasCapability(TunerCapRDS) {
+		t.Error("Uninitialized TunerInfo should not have TunerCapRDS")
+	}
+}
+
+// TestTunerInfo_IsStereo tests stereo capability checking
+func TestTunerInfo_IsStereo(t *testing.T) {
+	var info TunerInfo
+
+	// Zero capability means not stereo
+	if info.IsStereo() {
+		t.Error("Uninitialized TunerInfo should not be stereo")
+	}
+}
+
+// TestTunerInfo_HasRDS tests RDS capability checking
+func TestTunerInfo_HasRDS(t *testing.T) {
+	var info TunerInfo
+
+	// Zero capability means no RDS
+	if info.HasRDS() {
+		t.Error("Uninitialized TunerInfo should not have RDS")
+	}
+}
+
+// TestModulatorInfo_Accessors tests ModulatorInfo accessor methods
+func TestModulatorInfo_Accessors(t *testing.T) {
+	// Note: This test verifies the accessor methods exist and return correct types
+	// Actual functionality requires a real device or mock
+	var info ModulatorInfo
+
+	// Test that methods don't panic and return expected types
+	_ = info.GetIndex()
+	_ = info.GetName()
+	_ = info.GetCapability()
+	_ = info.GetRangeLow()
+	_ = info.GetRangeHigh()
+	_ = info.GetTxSubchans()
+	_ = info.GetType()
+
+	// All methods returned without panic - success
+}
+
+// TestModulatorInfo_CapabilityHelpers tests ModulatorInfo capability helper methods
+func TestModulatorInfo_CapabilityHelpers(t *testing.T) {
+	var info ModulatorInfo
+
+	// Test that helper methods don't panic
+	_ = info.HasCapability(TunerCapStereo)
+	_ = info.IsLowFreq()
+	_ = info.IsStereo()
+	_ = info.HasRDS()
+	_ = info.SupportsFreqBands()
+
+	// All methods returned without panic - success
+}
+
+// TestModulatorInfo_GetName tests name extraction from ModulatorInfo
+func TestModulatorInfo_GetName(t *testing.T) {
+	// This test verifies the GetName method works correctly
+	// The actual C struct initialization would require CGO setup
+	var info ModulatorInfo
+	name := info.GetName()
+
+	// Empty C string should return empty Go string
+	if name != "" {
+		t.Logf("GetName() returned: %q (expected empty for uninitialized struct)", name)
+	}
+}
+
+// TestModulatorInfo_HasCapability tests capability checking for modulator
+func TestModulatorInfo_HasCapability(t *testing.T) {
+	// This test verifies the HasCapability logic for ModulatorInfo
+	var info ModulatorInfo
+
+	// Zero capability means no capabilities
+	if info.HasCapability(TunerCapStereo) {
+		t.Error("Uninitialized ModulatorInfo should not have TunerCapStereo")
+	}
+
+	if info.HasCapability(TunerCapRDS) {
+		t.Error("Uninitialized ModulatorInfo should not have TunerCapRDS")
+	}
+}
+
+// TestFrequencyInfo_Accessors tests FrequencyInfo accessor methods
+func TestFrequencyInfo_Accessors(t *testing.T) {
+	var info FrequencyInfo
+
+	// Test that methods don't panic and return expected types
+	_ = info.GetTuner()
+	_ = info.GetType()
+	_ = info.GetFrequency()
+
+	// All methods returned without panic - success
+}
+
+// TestFrequencyBandInfo_Accessors tests FrequencyBandInfo accessor methods
+func TestFrequencyBandInfo_Accessors(t *testing.T) {
+	var info FrequencyBandInfo
+
+	// Test that methods don't panic and return expected types
+	_ = info.GetTuner()
+	_ = info.GetType()
+	_ = info.GetIndex()
+	_ = info.GetCapability()
+	_ = info.GetRangeLow()
+	_ = info.GetRangeHigh()
+	_ = info.GetModulation()
+	_ = info.HasCapability(TunerCapStereo)
+
+	// All methods returned without panic - success
+}
+
+// TestTunerModulator_SymmetryWithModulator verifies TunerInfo and ModulatorInfo have symmetric capability APIs
+func TestTunerModulator_SymmetryWithModulator(t *testing.T) {
+	// This test documents that TunerInfo and ModulatorInfo have similar capability APIs
+
+	commonMethods := []string{
+		"GetIndex",
+		"GetName",
+		"GetCapability",
+		"GetRangeLow",
+		"GetRangeHigh",
+		"GetType",
+		"HasCapability",
+		"IsLowFreq",
+		"IsStereo",
+		"HasRDS",
+		"SupportsFreqBands",
+	}
+
+	for _, method := range commonMethods {
+		t.Run(method, func(t *testing.T) {
+			// Both types implement these methods
+			t.Logf("Both TunerInfo and ModulatorInfo implement %s()", method)
+		})
+	}
+
+	t.Run("high_symmetry", func(t *testing.T) {
+		t.Log("TunerInfo and ModulatorInfo have highly symmetric APIs")
+		t.Log("Difference: TunerInfo has GetRxSubchans(), GetAudioMode(), GetSignal(), GetAFC()")
+		t.Log("Difference: ModulatorInfo has GetTxSubchans()")
+	})
+}
+
+// Note: Integration tests with actual V4L2 devices are in test/tuner_modulator_test.go
+// These unit tests focus on type definitions, constants, and accessor methods
+// without requiring real hardware or system calls.


### PR DESCRIPTION
The followings were added

Low-level core API - v4l2/tuner_info.go:
  - Full tuner/modulator structures with accessor methods
  - Frequency control (get/set with unit handling)
  - Frequency band enumeration
  - Signal strength & AFC monitoring

  High-level device API (device/device.go):
  - 6 tuner methods: GetTunerInfo, GetAllTuners, SetTuner, GetFrequency, SetFrequency, GetFrequencyBands
  - 3 modulator methods: GetModulatorInfo, GetAllModulators, SetModulator
  
Fixes #98 