### PR TITLE
issue-113: Support Direct Device Read IO

### DIFF
--- a/device/device.go
+++ b/device/device.go
@@ -83,20 +83,28 @@ type Device struct {
 
 	// framePool is the pool used for frame buffer allocation
 	framePool *FramePool
+
+	// readSeq is a monotonically increasing frame counter for ReadFrame()
+	readSeq uint32
 }
 
-// Open opens a V4L2 video device at the specified path and prepares it for streaming.
+// Open opens a V4L2 video device at the specified path and prepares it for use.
 // The device is opened in read-write mode with non-blocking I/O.
+//
+// The I/O method determines which APIs are available after opening:
+//   - IOMethodStreaming (default): Use Start/GetFrames/GetOutput/Stop for continuous capture
+//   - IOMethodReadWrite: Use Read/ReadFrame for synchronous frame access
 //
 // Parameters:
 //   - path: The file system path to the video device (e.g., "/dev/video0")
 //   - options: Optional configuration functions to customize device behavior
 //
 // Available options:
+//   - WithIOMethod(m): Set the I/O method (streaming or read/write)
 //   - WithBufferSize(n): Set the number of buffers for streaming (default: 2)
 //   - WithPixFormat(fmt): Set the pixel format and frame dimensions
 //   - WithFPS(fps): Set the frames per second for capture
-//   - WithIOType(io): Set the I/O method (currently only memory-mapped I/O is supported)
+//   - WithIOType(io): Set the memory type for streaming (only MMAP supported)
 //
 // The function performs the following initialization steps:
 //  1. Opens the device file descriptor
@@ -164,9 +172,16 @@ func Open(path string, options ...Option) (*Device, error) {
 		dev.config.bufSize = 2
 	}
 
-	// only supports streaming IO model right now
-	if !dev.cap.IsStreamingSupported() {
-		return nil, fmt.Errorf("device open: device does not support streamingIO")
+	// validate I/O method capability
+	switch dev.config.ioMethod {
+	case IOMethodReadWrite:
+		if !dev.cap.IsReadWriteSupported() {
+			return nil, fmt.Errorf("device open: device does not support read/write IO")
+		}
+	default: // IOMethodStreaming
+		if !dev.cap.IsStreamingSupported() {
+			return nil, fmt.Errorf("device open: device does not support streaming IO")
+		}
 	}
 
 	switch {
@@ -186,8 +201,10 @@ func Open(path string, options ...Option) (*Device, error) {
 		return nil, fmt.Errorf("device open: does not support buffer stream type")
 	}
 
-	// ensures IOType is set, only MemMap supported now
-	dev.config.ioType = v4l2.IOTypeMMAP
+	// set IOType for streaming mode (read/write mode doesn't use buffer API)
+	if dev.config.ioMethod == IOMethodStreaming {
+		dev.config.ioType = v4l2.IOTypeMMAP
+	}
 
 	// reset crop, only if cropping supported
 	if cropcap, err := v4l2.GetCropCapability(dev.fd, dev.bufType); err == nil {
@@ -1327,14 +1344,15 @@ func (d *Device) GetMediaInfo() (v4l2.MediaDeviceInfo, error) {
 // which is particularly useful for codec controls and compound controls.
 //
 // Example:
-//   ctrls := v4l2.NewExtControls()
-//   ctrls.Add(v4l2.NewExtControl(v4l2.CtrlBrightness))
-//   ctrls.Add(v4l2.NewExtControl(v4l2.CtrlContrast))
-//   if err := device.GetExtControls(ctrls); err != nil {
-//       return err
-//   }
-//   brightness := ctrls.GetControls()[0].GetValue()
-//   contrast := ctrls.GetControls()[1].GetValue()
+//
+//	ctrls := v4l2.NewExtControls()
+//	ctrls.Add(v4l2.NewExtControl(v4l2.CtrlBrightness))
+//	ctrls.Add(v4l2.NewExtControl(v4l2.CtrlContrast))
+//	if err := device.GetExtControls(ctrls); err != nil {
+//	    return err
+//	}
+//	brightness := ctrls.GetControls()[0].GetValue()
+//	contrast := ctrls.GetControls()[1].GetValue()
 func (d *Device) GetExtControls(ctrls *v4l2.ExtControls) error {
 	return v4l2.GetExtControls(d.fd, ctrls)
 }
@@ -1345,12 +1363,13 @@ func (d *Device) GetExtControls(ctrls *v4l2.ExtControls) error {
 // If any control fails, none of the controls are changed.
 //
 // Example:
-//   ctrls := v4l2.NewExtControls()
-//   ctrls.Add(v4l2.NewExtControlWithValue(v4l2.CtrlBrightness, 128))
-//   ctrls.Add(v4l2.NewExtControlWithValue(v4l2.CtrlContrast, 100))
-//   if err := device.SetExtControls(ctrls); err != nil {
-//       return err
-//   }
+//
+//	ctrls := v4l2.NewExtControls()
+//	ctrls.Add(v4l2.NewExtControlWithValue(v4l2.CtrlBrightness, 128))
+//	ctrls.Add(v4l2.NewExtControlWithValue(v4l2.CtrlContrast, 100))
+//	if err := device.SetExtControls(ctrls); err != nil {
+//	    return err
+//	}
 func (d *Device) SetExtControls(ctrls *v4l2.ExtControls) error {
 	return v4l2.SetExtControls(d.fd, ctrls)
 }
@@ -1360,13 +1379,14 @@ func (d *Device) SetExtControls(ctrls *v4l2.ExtControls) error {
 // This is useful for validating control values before applying them.
 //
 // Example:
-//   ctrls := v4l2.NewExtControls()
-//   ctrls.Add(v4l2.NewExtControlWithValue(v4l2.CtrlBrightness, 128))
-//   if err := device.TryExtControls(ctrls); err != nil {
-//       // Value would be rejected
-//       return err
-//   }
-//   // Value is valid, safe to apply
+//
+//	ctrls := v4l2.NewExtControls()
+//	ctrls.Add(v4l2.NewExtControlWithValue(v4l2.CtrlBrightness, 128))
+//	if err := device.TryExtControls(ctrls); err != nil {
+//	    // Value would be rejected
+//	    return err
+//	}
+//	// Value is valid, safe to apply
 func (d *Device) TryExtControls(ctrls *v4l2.ExtControls) error {
 	return v4l2.TryExtControls(d.fd, ctrls)
 }
@@ -1376,7 +1396,8 @@ func (d *Device) TryExtControls(ctrls *v4l2.ExtControls) error {
 // SetBrightness sets the brightness control value.
 //
 // Example:
-//   err := device.SetBrightness(128)
+//
+//	err := device.SetBrightness(128)
 func (d *Device) SetBrightness(value int32) error {
 	ctrls := v4l2.NewExtControls()
 	ctrls.AddValue(v4l2.CtrlBrightness, value)
@@ -1386,7 +1407,8 @@ func (d *Device) SetBrightness(value int32) error {
 // GetBrightness gets the current brightness value.
 //
 // Example:
-//   brightness, err := device.GetBrightness()
+//
+//	brightness, err := device.GetBrightness()
 func (d *Device) GetBrightness() (int32, error) {
 	ctrls := v4l2.NewExtControls()
 	ctrls.Add(v4l2.NewExtControl(v4l2.CtrlBrightness))
@@ -1399,7 +1421,8 @@ func (d *Device) GetBrightness() (int32, error) {
 // SetContrast sets the contrast control value.
 //
 // Example:
-//   err := device.SetContrast(100)
+//
+//	err := device.SetContrast(100)
 func (d *Device) SetContrast(value int32) error {
 	ctrls := v4l2.NewExtControls()
 	ctrls.AddValue(v4l2.CtrlContrast, value)
@@ -1409,7 +1432,8 @@ func (d *Device) SetContrast(value int32) error {
 // GetContrast gets the current contrast value.
 //
 // Example:
-//   contrast, err := device.GetContrast()
+//
+//	contrast, err := device.GetContrast()
 func (d *Device) GetContrast() (int32, error) {
 	ctrls := v4l2.NewExtControls()
 	ctrls.Add(v4l2.NewExtControl(v4l2.CtrlContrast))
@@ -1422,7 +1446,8 @@ func (d *Device) GetContrast() (int32, error) {
 // SetSaturation sets the saturation control value.
 //
 // Example:
-//   err := device.SetSaturation(64)
+//
+//	err := device.SetSaturation(64)
 func (d *Device) SetSaturation(value int32) error {
 	ctrls := v4l2.NewExtControls()
 	ctrls.AddValue(v4l2.CtrlSaturation, value)
@@ -1432,7 +1457,8 @@ func (d *Device) SetSaturation(value int32) error {
 // GetSaturation gets the current saturation value.
 //
 // Example:
-//   saturation, err := device.GetSaturation()
+//
+//	saturation, err := device.GetSaturation()
 func (d *Device) GetSaturation() (int32, error) {
 	ctrls := v4l2.NewExtControls()
 	ctrls.Add(v4l2.NewExtControl(v4l2.CtrlSaturation))
@@ -1445,7 +1471,8 @@ func (d *Device) GetSaturation() (int32, error) {
 // SetHue sets the hue control value.
 //
 // Example:
-//   err := device.SetHue(0)
+//
+//	err := device.SetHue(0)
 func (d *Device) SetHue(value int32) error {
 	ctrls := v4l2.NewExtControls()
 	ctrls.AddValue(v4l2.CtrlHue, value)
@@ -1455,7 +1482,8 @@ func (d *Device) SetHue(value int32) error {
 // GetHue gets the current hue value.
 //
 // Example:
-//   hue, err := device.GetHue()
+//
+//	hue, err := device.GetHue()
 func (d *Device) GetHue() (int32, error) {
 	ctrls := v4l2.NewExtControls()
 	ctrls.Add(v4l2.NewExtControl(v4l2.CtrlHue))
@@ -1473,17 +1501,19 @@ func (d *Device) GetHue() (int32, error) {
 // After subscribing, use DequeueEvent() to retrieve events from the device.
 //
 // Example - Subscribe to control change events:
-//   sub := v4l2.NewControlEventSubscription(v4l2.CtrlBrightness)
-//   sub.SetFlags(v4l2.EventSubFlagSendInitial)
-//   if err := device.SubscribeEvent(sub); err != nil {
-//       return err
-//   }
+//
+//	sub := v4l2.NewControlEventSubscription(v4l2.CtrlBrightness)
+//	sub.SetFlags(v4l2.EventSubFlagSendInitial)
+//	if err := device.SubscribeEvent(sub); err != nil {
+//	    return err
+//	}
 //
 // Example - Subscribe to all events:
-//   sub := v4l2.NewEventSubscription(v4l2.EventAll)
-//   if err := device.SubscribeEvent(sub); err != nil {
-//       return err
-//   }
+//
+//	sub := v4l2.NewEventSubscription(v4l2.EventAll)
+//	if err := device.SubscribeEvent(sub); err != nil {
+//	    return err
+//	}
 func (d *Device) SubscribeEvent(sub *v4l2.EventSubscription) error {
 	return v4l2.SubscribeEvent(d.fd, sub)
 }
@@ -1493,10 +1523,11 @@ func (d *Device) SubscribeEvent(sub *v4l2.EventSubscription) error {
 // The subscription parameter should match the original subscription.
 //
 // Example:
-//   sub := v4l2.NewEventSubscription(v4l2.EventCtrl)
-//   if err := device.UnsubscribeEvent(sub); err != nil {
-//       return err
-//   }
+//
+//	sub := v4l2.NewEventSubscription(v4l2.EventCtrl)
+//	if err := device.UnsubscribeEvent(sub); err != nil {
+//	    return err
+//	}
 func (d *Device) UnsubscribeEvent(sub *v4l2.EventSubscription) error {
 	return v4l2.UnsubscribeEvent(d.fd, sub)
 }
@@ -1509,23 +1540,27 @@ func (d *Device) UnsubscribeEvent(sub *v4l2.EventSubscription) error {
 // Returns the event and nil on success, or nil and an error if no event is available.
 //
 // Example:
-//   event, err := device.DequeueEvent()
-//   if err != nil {
-//       return err
-//   }
-//   switch event.GetType() {
-//   case v4l2.EventCtrl:
-//       ctrlData := event.GetCtrlData()
-//       fmt.Printf("Control changed: ID=%d, Value=%d\n", event.GetID(), ctrlData.Value)
-//   case v4l2.EventEOS:
-//       fmt.Println("End of stream")
-//   }
+//
+//	event, err := device.DequeueEvent()
+//	if err != nil {
+//	    return err
+//	}
+//	switch event.GetType() {
+//	case v4l2.EventCtrl:
+//	    ctrlData := event.GetCtrlData()
+//	    fmt.Printf("Control changed: ID=%d, Value=%d\n", event.GetID(), ctrlData.Value)
+//	case v4l2.EventEOS:
+//	    fmt.Println("End of stream")
+//	}
 func (d *Device) DequeueEvent() (*v4l2.Event, error) {
 	return v4l2.DequeueEvent(d.fd)
 }
 
-// Start begins video streaming from the device. This method allocates buffers,
-// memory-maps them, and starts a background goroutine to handle frame capture.
+// Start begins video streaming from the device. Only available in streaming I/O mode
+// (the default). Returns an error if the device was opened with IOMethodReadWrite.
+//
+// This method allocates buffers, memory-maps them, and starts a background
+// goroutine to handle frame capture.
 //
 // Parameters:
 //   - ctx: Context for cancellation and timeout control
@@ -1562,6 +1597,10 @@ func (d *Device) DequeueEvent() (*v4l2.Event, error) {
 func (d *Device) Start(ctx context.Context) error {
 	if ctx.Err() != nil {
 		return ctx.Err()
+	}
+
+	if d.config.ioMethod == IOMethodReadWrite {
+		return fmt.Errorf("device: Start() not supported in read/write IO mode; use Read() instead")
 	}
 
 	if !d.cap.IsStreamingSupported() {
@@ -1610,7 +1649,8 @@ func (d *Device) Start(ctx context.Context) error {
 	return nil
 }
 
-// Stop halts video streaming and releases streaming resources.
+// Stop halts video streaming and releases streaming resources. Only available in
+// streaming I/O mode. Returns an error if the device was opened with IOMethodReadWrite.
 // This method waits for the capture goroutine to exit, then unmaps buffers and stops the stream.
 //
 // The method ensures proper synchronization:
@@ -1624,6 +1664,10 @@ func (d *Device) Start(ctx context.Context) error {
 //
 // Returns an error if buffer unmapping or stream stopping fails.
 func (d *Device) Stop() error {
+	if d.config.ioMethod == IOMethodReadWrite {
+		return fmt.Errorf("device: Stop() not supported in read/write IO mode")
+	}
+
 	if !d.streaming.Load() {
 		return nil
 	}

--- a/device/device_config.go
+++ b/device/device_config.go
@@ -4,10 +4,29 @@ import (
 	"github.com/vladimirvivien/go4vl/v4l2"
 )
 
+// IOMethod defines the I/O method used by the device for frame transfer.
+type IOMethod int
+
+const (
+	// IOMethodStreaming uses continuous streaming with memory-mapped buffers.
+	// This is the default. Use Start/GetFrames/GetOutput/Stop to capture frames.
+	// Requires V4L2_CAP_STREAMING.
+	IOMethodStreaming IOMethod = iota
+
+	// IOMethodReadWrite uses direct read()/write() syscalls for frame transfer.
+	// Use Read/ReadFrame methods directly after Open. No Start/Stop needed.
+	// Simpler but less efficient than streaming. Requires V4L2_CAP_READWRITE.
+	IOMethodReadWrite
+)
+
 // config holds the internal configuration for a Device.
 // These settings are applied during device initialization and streaming setup.
 type config struct {
-	// ioType specifies the I/O method for frame transfer (memory-mapped, user pointer, etc.)
+	// ioMethod specifies the I/O method category (streaming or read/write)
+	ioMethod IOMethod
+
+	// ioType specifies the memory type for streaming I/O (MMAP, user pointer, etc.)
+	// Only applies when ioMethod is IOMethodStreaming.
 	ioType v4l2.IOType
 
 	// pixFormat defines the pixel format, frame dimensions, and color space
@@ -40,10 +59,28 @@ type Option func(*config)
 //
 //	device.Open("/dev/video0", device.WithIOType(v4l2.IOTypeMMAP))
 //
-// Note: This option is automatically set to IOTypeMMAP if not specified.
+// Note: This option only applies when using streaming I/O mode (the default).
+// It is ignored in read/write I/O mode. Automatically set to IOTypeMMAP if not specified.
 func WithIOType(ioType v4l2.IOType) Option {
 	return func(o *config) {
 		o.ioType = ioType
+	}
+}
+
+// WithIOMethod sets the I/O method for the device.
+// IOMethodStreaming (default) uses Start/GetFrames/Stop for continuous capture.
+// IOMethodReadWrite uses Read/ReadFrame for direct frame access.
+//
+// Example:
+//
+//	// Read/write mode — simple synchronous reads
+//	device.Open("/dev/video0", device.WithIOMethod(device.IOMethodReadWrite))
+//
+//	// Streaming mode (default) — continuous capture via channels
+//	device.Open("/dev/video0") // or device.WithIOMethod(device.IOMethodStreaming)
+func WithIOMethod(method IOMethod) Option {
+	return func(o *config) {
+		o.ioMethod = method
 	}
 }
 

--- a/device/device_test.go
+++ b/device/device_test.go
@@ -791,3 +791,78 @@ func TestDevice_StreamingMutualExclusivity(t *testing.T) {
 		}
 	})
 }
+
+// TestWithIOMethod tests the WithIOMethod option function
+func TestWithIOMethod(t *testing.T) {
+	tests := []struct {
+		name   string
+		method IOMethod
+	}{
+		{"Streaming", IOMethodStreaming},
+		{"ReadWrite", IOMethodReadWrite},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config{}
+			WithIOMethod(tt.method)(&cfg)
+			if cfg.ioMethod != tt.method {
+				t.Errorf("ioMethod = %d, want %d", cfg.ioMethod, tt.method)
+			}
+		})
+	}
+}
+
+// TestIOMethod_DefaultIsStreaming tests that zero value of IOMethod is streaming
+func TestIOMethod_DefaultIsStreaming(t *testing.T) {
+	cfg := config{}
+	if cfg.ioMethod != IOMethodStreaming {
+		t.Errorf("default ioMethod = %d, want IOMethodStreaming (0)", cfg.ioMethod)
+	}
+}
+
+// TestDevice_Start_RejectsReadWriteMode tests that Start() errors in read/write mode
+func TestDevice_Start_RejectsReadWriteMode(t *testing.T) {
+	dev := Device{
+		cap: v4l2.Capability{
+			Capabilities: v4l2.CapVideoCapture | v4l2.CapReadWrite,
+		},
+		config: config{ioMethod: IOMethodReadWrite},
+	}
+	err := dev.Start(context.Background())
+	if err == nil {
+		t.Error("Start() should return error in read/write mode")
+	}
+}
+
+// TestDevice_Stop_RejectsReadWriteMode tests that Stop() errors in read/write mode
+func TestDevice_Stop_RejectsReadWriteMode(t *testing.T) {
+	dev := Device{
+		config: config{ioMethod: IOMethodReadWrite},
+	}
+	err := dev.Stop()
+	if err == nil {
+		t.Error("Stop() should return error in read/write mode")
+	}
+}
+
+// TestDevice_Read_RejectsStreamingMode tests that Read() errors in streaming mode
+func TestDevice_Read_RejectsStreamingMode(t *testing.T) {
+	dev := Device{
+		config: config{ioMethod: IOMethodStreaming},
+	}
+	_, err := dev.Read(make([]byte, 1024))
+	if err == nil {
+		t.Error("Read() should return error in streaming mode")
+	}
+}
+
+// TestDevice_ReadFrame_RejectsStreamingMode tests that ReadFrame() errors in streaming mode
+func TestDevice_ReadFrame_RejectsStreamingMode(t *testing.T) {
+	dev := Device{
+		config: config{ioMethod: IOMethodStreaming},
+	}
+	_, err := dev.ReadFrame()
+	if err == nil {
+		t.Error("ReadFrame() should return error in streaming mode")
+	}
+}

--- a/device/readwrite.go
+++ b/device/readwrite.go
@@ -1,0 +1,85 @@
+package device
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/vladimirvivien/go4vl/v4l2"
+	sys "golang.org/x/sys/unix"
+)
+
+// Read reads a single frame from the device into buf.
+// Returns the number of bytes read.
+//
+// Only available when the device is opened with IOMethodReadWrite.
+// The buffer should be at least SizeImage bytes (from GetPixFormat().SizeImage).
+//
+// Read blocks until a frame is available. The device is opened with O_NONBLOCK,
+// so EAGAIN is returned if no frame is ready yet.
+//
+// Example:
+//
+//	dev, _ := device.Open("/dev/video0", device.WithIOMethod(device.IOMethodReadWrite))
+//	defer dev.Close()
+//
+//	pf, _ := dev.GetPixFormat()
+//	buf := make([]byte, pf.SizeImage)
+//	n, err := dev.Read(buf)
+//	// buf[:n] contains the frame data
+func (d *Device) Read(buf []byte) (int, error) {
+	if d.config.ioMethod != IOMethodReadWrite {
+		return 0, fmt.Errorf("device: Read() not supported in streaming IO mode; use Start/GetFrames instead")
+	}
+
+	n, err := v4l2.ReadDevice(d.fd, buf)
+	if err != nil {
+		if errors.Is(err, sys.EAGAIN) || errors.Is(err, sys.EINTR) {
+			return 0, err
+		}
+		return 0, fmt.Errorf("device: read: %w", err)
+	}
+	return n, nil
+}
+
+// ReadFrame reads a single frame from the device and returns it as a *Frame
+// with metadata, providing parity with the streaming GetFrames() API.
+//
+// Each call allocates a fresh buffer. The returned Frame.Data is valid until
+// the caller discards it (no Release() needed, unlike streaming mode frames).
+//
+// Only available when the device is opened with IOMethodReadWrite.
+//
+// Example:
+//
+//	dev, _ := device.Open("/dev/video0", device.WithIOMethod(device.IOMethodReadWrite))
+//	defer dev.Close()
+//
+//	for i := 0; i < 10; i++ {
+//	    frame, err := dev.ReadFrame()
+//	    if err != nil { break }
+//	    fmt.Printf("Frame %d: %d bytes at %v\n", frame.Sequence, len(frame.Data), frame.Timestamp)
+//	}
+func (d *Device) ReadFrame() (*Frame, error) {
+	if d.config.ioMethod != IOMethodReadWrite {
+		return nil, fmt.Errorf("device: ReadFrame() not supported in streaming IO mode; use Start/GetFrames instead")
+	}
+
+	buf := make([]byte, d.config.pixFormat.SizeImage)
+	n, err := v4l2.ReadDevice(d.fd, buf)
+	if err != nil {
+		if errors.Is(err, sys.EAGAIN) || errors.Is(err, sys.EINTR) {
+			return nil, err
+		}
+		return nil, fmt.Errorf("device: read frame: %w", err)
+	}
+
+	frame := &Frame{
+		Data:      buf[:n],
+		Timestamp: time.Now(),
+		Sequence:  d.readSeq,
+	}
+	d.readSeq++
+
+	return frame, nil
+}

--- a/examples/readwrite_capture/README.md
+++ b/examples/readwrite_capture/README.md
@@ -1,0 +1,44 @@
+# Read/Write Capture Example
+
+Demonstrates frame capture using the **read/write I/O method**, an alternative to the default streaming mode.
+
+## Read/Write vs Streaming
+
+| | Streaming (default) | Read/Write |
+|---|---|---|
+| **API** | `Start → GetFrames → Stop` | `Read` or `ReadFrame` |
+| **Flow** | Continuous, channel-based | Synchronous, one frame at a time |
+| **Performance** | Zero-copy (MMAP) | Extra copy per frame |
+| **Complexity** | Higher (buffer lifecycle) | Lower (one syscall) |
+| **Capability** | `V4L2_CAP_STREAMING` | `V4L2_CAP_READWRITE` |
+
+Use read/write mode when:
+- You need simple, synchronous frame access
+- The device doesn't support streaming
+- Performance is not critical
+
+## Usage
+
+```bash
+# Capture 5 frames using ReadFrame() (high-level API with metadata)
+go run . -d /dev/video0 -n 5
+
+# Capture 5 frames using Read() (low-level API)
+go run . -d /dev/video0 -n 5 -raw
+```
+
+## Flags
+
+- `-d` — Device path (default: `/dev/video0`)
+- `-n` — Number of frames to capture (default: 5)
+- `-raw` — Use low-level `Read()` instead of `ReadFrame()`
+
+## Output
+
+Frames are saved as `frame_0.jpg`, `frame_1.jpg`, etc.
+
+```
+Format: 640x480, SizeImage: 614400
+Frame 0: seq=0, 12543 bytes, ts=2026-04-05 10:30:00 -> frame_0.jpg
+Frame 1: seq=1, 12601 bytes, ts=2026-04-05 10:30:00 -> frame_1.jpg
+```

--- a/examples/readwrite_capture/main.go
+++ b/examples/readwrite_capture/main.go
@@ -1,0 +1,90 @@
+// readwrite_capture demonstrates frame capture using the read/write I/O method.
+//
+// Unlike streaming mode (Start/GetFrames/Stop), read/write mode uses direct
+// read() syscalls for simple, synchronous frame capture.
+//
+// Usage:
+//
+//	readwrite_capture -d /dev/video0 -n 5
+//	readwrite_capture -d /dev/video0 -n 5 -raw
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/vladimirvivien/go4vl/device"
+	"github.com/vladimirvivien/go4vl/v4l2"
+)
+
+func main() {
+	devName := "/dev/video0"
+	numFrames := 5
+	useRaw := false
+	flag.StringVar(&devName, "d", devName, "device name (path)")
+	flag.IntVar(&numFrames, "n", numFrames, "number of frames to capture")
+	flag.BoolVar(&useRaw, "raw", useRaw, "use low-level Read() instead of ReadFrame()")
+	flag.Parse()
+
+	dev, err := device.Open(
+		devName,
+		device.WithIOMethod(device.IOMethodReadWrite),
+		device.WithPixFormat(v4l2.PixFormat{
+			PixelFormat: v4l2.PixelFmtMJPEG,
+			Width:       640,
+			Height:      480,
+		}),
+	)
+	if err != nil {
+		log.Fatalf("failed to open device: %s", err)
+	}
+	defer dev.Close()
+
+	pixFmt, err := dev.GetPixFormat()
+	if err != nil {
+		log.Fatalf("failed to get pixel format: %s", err)
+	}
+	log.Printf("Format: %dx%d, SizeImage: %d", pixFmt.Width, pixFmt.Height, pixFmt.SizeImage)
+
+	if useRaw {
+		captureRaw(dev, pixFmt, numFrames)
+	} else {
+		captureFrames(dev, numFrames)
+	}
+}
+
+func captureRaw(dev *device.Device, pixFmt v4l2.PixFormat, n int) {
+	buf := make([]byte, pixFmt.SizeImage)
+	for i := 0; i < n; i++ {
+		bytesRead, err := dev.Read(buf)
+		if err != nil {
+			log.Fatalf("Read() failed: %s", err)
+		}
+
+		fileName := fmt.Sprintf("frame_%d.jpg", i)
+		if err := os.WriteFile(fileName, buf[:bytesRead], 0644); err != nil {
+			log.Printf("failed to write %s: %s", fileName, err)
+			continue
+		}
+		log.Printf("Frame %d: %d bytes -> %s", i, bytesRead, fileName)
+	}
+}
+
+func captureFrames(dev *device.Device, n int) {
+	for i := 0; i < n; i++ {
+		frame, err := dev.ReadFrame()
+		if err != nil {
+			log.Fatalf("ReadFrame() failed: %s", err)
+		}
+
+		fileName := fmt.Sprintf("frame_%d.jpg", i)
+		if err := os.WriteFile(fileName, frame.Data, 0644); err != nil {
+			log.Printf("failed to write %s: %s", fileName, err)
+			continue
+		}
+		log.Printf("Frame %d: seq=%d, %d bytes, ts=%v -> %s",
+			i, frame.Sequence, len(frame.Data), frame.Timestamp, fileName)
+	}
+}

--- a/test/device_test.go
+++ b/test/device_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package test
@@ -580,4 +581,106 @@ func TestDevice_DeviceInfo(t *testing.T) {
 		}
 		t.Logf("File descriptor: %d", fd)
 	})
+}
+
+// TestDevice_ReadWrite tests the read/write I/O method.
+func TestDevice_ReadWrite(t *testing.T) {
+	devicePath := RequireV4L2Testing(t)
+
+	// Test Start/Stop rejection with a shared device
+	t.Run("Start_Stop_Errors", func(t *testing.T) {
+		dev := OpenDeviceOrSkip(t, devicePath,
+			device.WithIOMethod(device.IOMethodReadWrite),
+		)
+		if !dev.Capability().IsReadWriteSupported() {
+			t.Skip("Device does not support read/write IO")
+		}
+
+		err := dev.Start(context.Background())
+		if err == nil {
+			t.Error("Start() should return error in read/write mode")
+		}
+		t.Logf("Start() correctly returned error: %v", err)
+
+		err = dev.Stop()
+		if err == nil {
+			t.Error("Stop() should return error in read/write mode")
+		}
+		t.Logf("Stop() correctly returned error: %v", err)
+	})
+
+	// Test Read — uses its own device to avoid state contamination
+	t.Run("Read", func(t *testing.T) {
+		dev := OpenDeviceOrSkip(t, devicePath,
+			device.WithIOMethod(device.IOMethodReadWrite),
+		)
+		if !dev.Capability().IsReadWriteSupported() {
+			t.Skip("Device does not support read/write IO")
+		}
+		pixFmt, err := dev.GetPixFormat()
+		if err != nil {
+			t.Fatalf("GetPixFormat() = %v", err)
+		}
+		if pixFmt.SizeImage == 0 {
+			t.Skip("Device reports SizeImage=0")
+		}
+
+		buf := make([]byte, pixFmt.SizeImage)
+		for i := 0; i < 3; i++ {
+			n, err := dev.Read(buf)
+			if err != nil {
+				// v4l2loopback reports CAP_READWRITE but read() returns error
+				// when no producer is feeding data to the loopback device
+				if isDeviceError(err) {
+					t.Skipf("read() not functional (no data source): %v", err)
+				}
+				t.Fatalf("Read() = %v", err)
+			}
+			if n == 0 {
+				t.Error("Read() returned 0 bytes")
+			}
+			t.Logf("Frame %d: %d bytes", i, n)
+		}
+	})
+
+	// Test ReadFrame — uses its own device to avoid state contamination
+	t.Run("ReadFrame", func(t *testing.T) {
+		dev := OpenDeviceOrSkip(t, devicePath,
+			device.WithIOMethod(device.IOMethodReadWrite),
+		)
+		if !dev.Capability().IsReadWriteSupported() {
+			t.Skip("Device does not support read/write IO")
+		}
+
+		var prevSeq uint32
+		for i := 0; i < 3; i++ {
+			frame, err := dev.ReadFrame()
+			if err != nil {
+				if isDeviceError(err) {
+					t.Skipf("read() not functional (no data source): %v", err)
+				}
+				t.Fatalf("ReadFrame() = %v", err)
+			}
+			if len(frame.Data) == 0 {
+				t.Error("ReadFrame() returned empty data")
+			}
+			if frame.Timestamp.IsZero() {
+				t.Error("ReadFrame() returned zero timestamp")
+			}
+			if i > 0 && frame.Sequence <= prevSeq {
+				t.Errorf("Sequence not incrementing: got %d, prev %d", frame.Sequence, prevSeq)
+			}
+			prevSeq = frame.Sequence
+			t.Logf("Frame %d: seq=%d, %d bytes, ts=%v", i, frame.Sequence, len(frame.Data), frame.Timestamp)
+		}
+	})
+}
+
+// isDeviceError returns true for device errors that indicate the read/write
+// I/O method is not functional (e.g., loopback device with no data source).
+func isDeviceError(err error) bool {
+	msg := err.Error()
+	return strings.Contains(msg, "input/output error") ||
+		strings.Contains(msg, "device or resource busy") ||
+		strings.Contains(msg, "bad file descriptor")
 }

--- a/v4l2/syscalls.go
+++ b/v4l2/syscalls.go
@@ -54,6 +54,16 @@ func closeDev(fd uintptr) error {
 	return sys.Close(int(fd))
 }
 
+// ReadDevice reads frame data from a V4L2 device using the read() syscall.
+// The device must support V4L2_CAP_READWRITE.
+func ReadDevice(fd uintptr, buf []byte) (int, error) {
+	n, err := sys.Read(int(fd), buf)
+	if err != nil {
+		return n, fmt.Errorf("read device: %w", err)
+	}
+	return n, nil
+}
+
 // ioctl is a wrapper for Syscall(SYS_IOCTL)
 func ioctl(fd, req, arg uintptr) (err sys.Errno) {
 	for {

--- a/v4l2/syscalls_test.go
+++ b/v4l2/syscalls_test.go
@@ -147,18 +147,25 @@ func TestWaitForRead_ConcurrentContextCancellation(t *testing.T) {
 			// Let it run briefly
 			time.Sleep(20 * time.Millisecond)
 
-			// Cancel
+			// Cancel and wait for channel closure.
+			// The goroutine may have sent a signal before seeing the
+			// cancellation, so drain any in-flight signals first.
 			cancel()
 
-			// Verify closure
-			select {
-			case _, ok := <-sigChan:
-				if ok {
-					t.Errorf("Goroutine %d: Expected channel to be closed", id)
+			timeout := time.After(500 * time.Millisecond)
+			for {
+				select {
+				case _, ok := <-sigChan:
+					if !ok {
+						goto closed
+					}
+					// Signal sent before cancel was seen — drain and retry
+				case <-timeout:
+					t.Errorf("Goroutine %d: Channel did not close within timeout", id)
+					goto closed
 				}
-			case <-time.After(200 * time.Millisecond):
-				t.Errorf("Goroutine %d: Channel did not close within timeout", id)
 			}
+		closed:
 
 			done <- true
 		}(i)


### PR DESCRIPTION
This PR (fixes #113) introduces support for direct device read (and later write) IO. This feature is useful for devices that do not support streaming (photo-only cameras).

```go
  // Streaming (default — unchanged)
  dev, _ := device.Open("/dev/video0")
  dev.Start(ctx)
  for frame := range dev.GetFrames() { ... }
  dev.Stop()

  // Read/Write <--- new
  dev, _ := device.Open("/dev/video0", device.WithIOMethod(device.IOMethodReadWrite))
  n, _ := dev.Read(buf)           // low-level
  frame, _ := dev.ReadFrame()     // high-level with metadata
  dev.Close()
```  

Notice the introduction of type `device.IOMethod` with values:
- `device.IOMethodStreaming` - for streaming input/output
- `device.IOMethodReadWrite` - for direct device Read/Write IO