### PR TITLE
issue-115: Support User Pointer Streaming Input

### DIFF
--- a/device/capture_bytes.go
+++ b/device/capture_bytes.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	sys "syscall"
+	"unsafe"
 
 	"github.com/vladimirvivien/go4vl/v4l2"
 )
@@ -55,7 +56,8 @@ func (d *Device) startRawBytesCapture() {
 				}
 
 				// Process buffer based on its state
-				isMapped := buff.Flags&v4l2.BufFlagMapped != 0
+				// For USERPTR, buffers are always valid (app-allocated)
+				isMapped := (ioMemType == v4l2.IOTypeUserPtr) || (buff.Flags&v4l2.BufFlagMapped != 0)
 				hasError := buff.Flags&v4l2.BufFlagError != 0
 				hasData := buff.BytesUsed > 0
 
@@ -114,10 +116,17 @@ func (d *Device) startRawBytesCapture() {
 					}
 				}
 
-				if _, err := v4l2.QueueBuffer(fd, ioMemType, bufType, buff.Index); err != nil {
-					// Send error and exit gracefully
+				var queueErr error
+				switch ioMemType {
+				case v4l2.IOTypeUserPtr:
+					ptr := uintptr(unsafe.Pointer(&d.buffers[buff.Index][0]))
+					_, queueErr = v4l2.QueueBufferUserPtr(fd, bufType, buff.Index, ptr, uint32(len(d.buffers[buff.Index])))
+				default:
+					_, queueErr = v4l2.QueueBuffer(fd, ioMemType, bufType, buff.Index)
+				}
+				if queueErr != nil {
 					select {
-					case d.streamErr <- fmt.Errorf("device: stream loop queue: %w: buff: %#v", err, buff):
+					case d.streamErr <- fmt.Errorf("device: stream loop queue: %w: buff: %#v", queueErr, buff):
 					default:
 					}
 					return

--- a/device/capture_frames.go
+++ b/device/capture_frames.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	sys "syscall"
 	"time"
+	"unsafe"
 
 	"github.com/vladimirvivien/go4vl/v4l2"
 )
@@ -56,7 +57,8 @@ func (d *Device) startFramesCapture() {
 				}
 
 				// Process buffer based on its state
-				isMapped := buff.Flags&v4l2.BufFlagMapped != 0
+				// For USERPTR, buffers are always valid (app-allocated)
+				isMapped := (ioMemType == v4l2.IOTypeUserPtr) || (buff.Flags&v4l2.BufFlagMapped != 0)
 				hasError := buff.Flags&v4l2.BufFlagError != 0
 				hasData := buff.BytesUsed > 0
 
@@ -110,13 +112,20 @@ func (d *Device) startFramesCapture() {
 					default:
 					}
 
-				// Other cases (no data, not mapped) are silently skipped
+					// Other cases (no data, not mapped) are silently skipped
 				}
 
-				if _, err := v4l2.QueueBuffer(fd, ioMemType, bufType, buff.Index); err != nil {
-					// Send error and exit gracefully
+				var queueErr error
+				switch ioMemType {
+				case v4l2.IOTypeUserPtr:
+					ptr := uintptr(unsafe.Pointer(&d.buffers[buff.Index][0]))
+					_, queueErr = v4l2.QueueBufferUserPtr(fd, bufType, buff.Index, ptr, uint32(len(d.buffers[buff.Index])))
+				default:
+					_, queueErr = v4l2.QueueBuffer(fd, ioMemType, bufType, buff.Index)
+				}
+				if queueErr != nil {
 					select {
-					case d.streamErr <- fmt.Errorf("device: stream loop queue: %w: buff: %#v", err, buff):
+					case d.streamErr <- fmt.Errorf("device: stream loop queue: %w: buff: %#v", queueErr, buff):
 					default:
 					}
 					return

--- a/device/device.go
+++ b/device/device.go
@@ -6,6 +6,7 @@ import (
 	"sync/atomic"
 	sys "syscall"
 	"time"
+	"unsafe"
 
 	"github.com/vladimirvivien/go4vl/v4l2"
 )
@@ -203,7 +204,12 @@ func Open(path string, options ...Option) (*Device, error) {
 
 	// set IOType for streaming mode (read/write mode doesn't use buffer API)
 	if dev.config.ioMethod == IOMethodStreaming {
-		dev.config.ioType = v4l2.IOTypeMMAP
+		switch dev.config.ioType {
+		case v4l2.IOTypeUserPtr:
+			// user explicitly selected USERPTR
+		default:
+			dev.config.ioType = v4l2.IOTypeMMAP
+		}
 	}
 
 	// reset crop, only if cropping supported
@@ -1622,16 +1628,30 @@ func (d *Device) Start(ctx context.Context) error {
 	d.config.bufSize = bufReq.Count
 	d.requestedBuf = bufReq
 
-	// for each allocated device buf, map into local space
-	if d.buffers, err = v4l2.MapMemoryBuffers(d); err != nil {
-		return fmt.Errorf("device: make mapped buffers: %s", err)
+	// set up buffers based on I/O type
+	switch d.config.ioType {
+	case v4l2.IOTypeUserPtr:
+		d.buffers = v4l2.AllocateUserBuffers(int(d.config.bufSize), d.config.pixFormat.SizeImage)
+	default: // IOTypeMMAP
+		if d.buffers, err = v4l2.MapMemoryBuffers(d); err != nil {
+			return fmt.Errorf("device: make mapped buffers: %s", err)
+		}
 	}
 
 	// Queue buffers for capture
 	for i := 0; i < int(d.config.bufSize); i++ {
-		if _, err := v4l2.QueueBuffer(d.fd, d.config.ioType, d.bufType, uint32(i)); err != nil {
-			d.streaming.Store(false)
-			return fmt.Errorf("device: buffer queueing: %w", err)
+		switch d.config.ioType {
+		case v4l2.IOTypeUserPtr:
+			ptr := uintptr(unsafe.Pointer(&d.buffers[i][0]))
+			if _, err := v4l2.QueueBufferUserPtr(d.fd, d.bufType, uint32(i), ptr, uint32(len(d.buffers[i]))); err != nil {
+				d.streaming.Store(false)
+				return fmt.Errorf("device: buffer queueing: %w", err)
+			}
+		default:
+			if _, err := v4l2.QueueBuffer(d.fd, d.config.ioType, d.bufType, uint32(i)); err != nil {
+				d.streaming.Store(false)
+				return fmt.Errorf("device: buffer queueing: %w", err)
+			}
 		}
 	}
 
@@ -1688,8 +1708,10 @@ func (d *Device) Stop() error {
 		}
 	}
 
-	if err := v4l2.UnmapMemoryBuffers(d); err != nil {
-		return fmt.Errorf("device: stop: %w", err)
+	if d.config.ioType == v4l2.IOTypeMMAP {
+		if err := v4l2.UnmapMemoryBuffers(d); err != nil {
+			return fmt.Errorf("device: stop: %w", err)
+		}
 	}
 	if err := v4l2.StreamOff(d); err != nil {
 		return fmt.Errorf("device: stop: %w", err)

--- a/device/device_config.go
+++ b/device/device_config.go
@@ -46,13 +46,12 @@ type config struct {
 // Options are applied in the order they are provided to the Open function.
 type Option func(*config)
 
-// WithIOType sets the I/O method for video streaming.
-// Currently, only memory-mapped I/O (IOTypeMMAP) is fully supported.
+// WithIOType sets the buffer memory type for streaming I/O.
+// Only applies when using IOMethodStreaming (the default).
 //
 // Available I/O types:
-//   - IOTypeMMAP: Memory-mapped I/O (recommended, zero-copy)
-//   - IOTypeUserPtr: User pointer I/O (not yet supported)
-//   - IOTypeReadWrite: Read/write I/O (not recommended for streaming)
+//   - IOTypeMMAP: Memory-mapped I/O (default, zero-copy from kernel)
+//   - IOTypeUserPtr: User pointer I/O (application-allocated buffers)
 //   - IOTypeDMABuf: DMA buffer sharing (not yet supported)
 //
 // Example:

--- a/device/device_test.go
+++ b/device/device_test.go
@@ -866,3 +866,34 @@ func TestDevice_ReadFrame_RejectsStreamingMode(t *testing.T) {
 		t.Error("ReadFrame() should return error in streaming mode")
 	}
 }
+
+// TestWithIOType_UserPtr tests that WithIOType sets USERPTR correctly
+func TestWithIOType_UserPtr(t *testing.T) {
+	cfg := config{}
+	WithIOType(v4l2.IOTypeUserPtr)(&cfg)
+	if cfg.ioType != v4l2.IOTypeUserPtr {
+		t.Errorf("ioType = %d, want IOTypeUserPtr (%d)", cfg.ioType, v4l2.IOTypeUserPtr)
+	}
+}
+
+// TestIOType_DefaultIsZero tests that default ioType is zero (resolved to MMAP in Open)
+func TestIOType_DefaultIsZero(t *testing.T) {
+	cfg := config{}
+	if cfg.ioType != 0 {
+		t.Errorf("default ioType = %d, want 0", cfg.ioType)
+	}
+}
+
+// TestUserPtr_WithStreamingMethod tests USERPTR works alongside IOMethodStreaming
+func TestUserPtr_WithStreamingMethod(t *testing.T) {
+	cfg := config{}
+	WithIOMethod(IOMethodStreaming)(&cfg)
+	WithIOType(v4l2.IOTypeUserPtr)(&cfg)
+
+	if cfg.ioMethod != IOMethodStreaming {
+		t.Errorf("ioMethod = %d, want IOMethodStreaming", cfg.ioMethod)
+	}
+	if cfg.ioType != v4l2.IOTypeUserPtr {
+		t.Errorf("ioType = %d, want IOTypeUserPtr", cfg.ioType)
+	}
+}

--- a/examples/userptr_capture/README.md
+++ b/examples/userptr_capture/README.md
@@ -1,0 +1,36 @@
+# User Pointer Capture Example
+
+Demonstrates frame capture using **User Pointer (USERPTR) streaming I/O**, an alternative to the default MMAP streaming mode.
+
+## MMAP vs USERPTR
+
+| | MMAP (default) | USERPTR |
+|---|---|---|
+| **Buffer allocation** | Kernel allocates | Application allocates |
+| **Buffer mapping** | `mmap()` into userspace | Direct pointer access |
+| **Performance** | Zero-copy from kernel | One copy per frame |
+| **Use case** | General purpose | Custom allocators, shared memory |
+
+The consumer API (`Start/GetFrames/Stop`) is identical for both modes.
+
+## Usage
+
+```bash
+# Capture 5 frames using USERPTR streaming
+go run . -d /dev/video0 -n 5
+```
+
+## Flags
+
+- `-d` — Device path (default: `/dev/video0`)
+- `-n` — Number of frames to capture (default: 5)
+
+## Output
+
+Frames are saved as `frame_0.jpg`, `frame_1.jpg`, etc.
+
+```
+Frame 0: seq=0, 12543 bytes, ts=2026-04-05 10:30:00 -> frame_0.jpg
+Frame 1: seq=1, 12601 bytes, ts=2026-04-05 10:30:00 -> frame_1.jpg
+Captured 5 frames
+```

--- a/examples/userptr_capture/main.go
+++ b/examples/userptr_capture/main.go
@@ -1,0 +1,74 @@
+// userptr_capture demonstrates frame capture using User Pointer streaming I/O.
+//
+// Unlike the default MMAP mode where the kernel allocates buffers, USERPTR mode
+// uses application-allocated buffers. The consumer API (Start/GetFrames/Stop)
+// is identical — the difference is internal.
+//
+// Usage:
+//
+//	userptr_capture -d /dev/video0 -n 5
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/vladimirvivien/go4vl/device"
+	"github.com/vladimirvivien/go4vl/v4l2"
+)
+
+func main() {
+	devName := "/dev/video0"
+	numFrames := 5
+	flag.StringVar(&devName, "d", devName, "device name (path)")
+	flag.IntVar(&numFrames, "n", numFrames, "number of frames to capture")
+	flag.Parse()
+
+	dev, err := device.Open(
+		devName,
+		device.WithIOType(v4l2.IOTypeUserPtr),
+		device.WithPixFormat(v4l2.PixFormat{
+			PixelFormat: v4l2.PixelFmtMJPEG,
+			Width:       640,
+			Height:      480,
+		}),
+		device.WithBufferSize(4),
+	)
+	if err != nil {
+		log.Fatalf("failed to open device: %s", err)
+	}
+	defer dev.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := dev.Start(ctx); err != nil {
+		log.Fatalf("failed to start stream: %s", err)
+	}
+
+	count := 0
+	for frame := range dev.GetFrames() {
+		fileName := fmt.Sprintf("frame_%d.jpg", count)
+		if err := os.WriteFile(fileName, frame.Data, 0644); err != nil {
+			log.Printf("failed to write %s: %s", fileName, err)
+			frame.Release()
+			continue
+		}
+		log.Printf("Frame %d: seq=%d, %d bytes, ts=%v -> %s",
+			count, frame.Sequence, len(frame.Data), frame.Timestamp, fileName)
+		frame.Release()
+		count++
+		if count >= numFrames {
+			break
+		}
+	}
+
+	if err := dev.Stop(); err != nil {
+		log.Fatalf("failed to stop stream: %s", err)
+	}
+	log.Printf("Captured %d frames", count)
+}

--- a/test/device_test.go
+++ b/test/device_test.go
@@ -676,11 +676,56 @@ func TestDevice_ReadWrite(t *testing.T) {
 	})
 }
 
-// isDeviceError returns true for device errors that indicate the read/write
-// I/O method is not functional (e.g., loopback device with no data source).
+// TestDevice_UserPtr tests USERPTR streaming I/O.
+func TestDevice_UserPtr(t *testing.T) {
+	devicePath := RequireV4L2Testing(t)
+
+	dev := OpenDeviceOrSkip(t, devicePath,
+		device.WithIOType(v4l2.IOTypeUserPtr),
+		device.WithBufferSize(4),
+	)
+
+	if !dev.Capability().IsStreamingSupported() {
+		t.Skip("Device does not support streaming IO")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := dev.Start(ctx); err != nil {
+		if isDeviceError(err) {
+			t.Skipf("USERPTR not functional on this device: %v", err)
+		}
+		t.Fatalf("Start() = %v", err)
+	}
+	defer dev.Stop()
+
+	t.Run("GetFrames", func(t *testing.T) {
+		count := 0
+		for frame := range dev.GetFrames() {
+			if len(frame.Data) == 0 {
+				continue
+			}
+			t.Logf("Frame %d: seq=%d, %d bytes", count, frame.Sequence, len(frame.Data))
+			frame.Release()
+			count++
+			if count >= 3 {
+				break
+			}
+		}
+		if count < 3 {
+			t.Errorf("Captured %d frames, want at least 3", count)
+		}
+	})
+}
+
+// isDeviceError returns true for device errors that indicate the I/O method
+// is not functional (e.g., loopback device with no data source, or unsupported mode).
 func isDeviceError(err error) bool {
 	msg := err.Error()
 	return strings.Contains(msg, "input/output error") ||
 		strings.Contains(msg, "device or resource busy") ||
-		strings.Contains(msg, "bad file descriptor")
+		strings.Contains(msg, "bad file descriptor") ||
+		strings.Contains(msg, "bad argument") ||
+		strings.Contains(msg, "type not supported")
 }

--- a/v4l2/streaming.go
+++ b/v4l2/streaming.go
@@ -102,7 +102,7 @@ const (
 
 	// BufFlagError indicates an error occurred during capture/output.
 	// The buffer contents are likely invalid.
-	BufFlagError BufFlag = C.V4L2_BUF_FLAG_ERROR
+	BufFlagError               BufFlag = C.V4L2_BUF_FLAG_ERROR
 	BufFlagInRequest           BufFlag = C.V4L2_BUF_FLAG_IN_REQUEST
 	BufFlagTimeCode            BufFlag = C.V4L2_BUF_FLAG_TIMECODE
 	BufFlagM2MHoldCaptureBuf   BufFlag = C.V4L2_BUF_FLAG_M2M_HOLD_CAPTURE_BUF
@@ -228,7 +228,7 @@ func StreamOff(dev StreamingDevice) error {
 // for video capture or video output when using either mem map, user pointer, or DMA buffers.
 // See https://www.kernel.org/doc/html/latest/userspace-api/media/v4l/vidioc-reqbufs.html#vidioc-reqbufs
 func InitBuffers(dev StreamingDevice) (RequestBuffers, error) {
-	if dev.MemIOType() != IOTypeMMAP && dev.MemIOType() != IOTypeDMABuf {
+	if dev.MemIOType() != IOTypeMMAP && dev.MemIOType() != IOTypeUserPtr && dev.MemIOType() != IOTypeDMABuf {
 		return RequestBuffers{}, fmt.Errorf("request buffers: %w", ErrorUnsupported)
 	}
 	var req C.struct_v4l2_requestbuffers
@@ -247,7 +247,7 @@ func InitBuffers(dev StreamingDevice) (RequestBuffers, error) {
 // buffers. Useful when shuttingdown the stream.
 // See https://linuxtv.org/downloads/v4l-dvb-apis-new/userspace-api/v4l/vidioc-reqbufs.html
 func ResetBuffers(dev StreamingDevice) (RequestBuffers, error) {
-	if dev.MemIOType() != IOTypeMMAP && dev.MemIOType() != IOTypeDMABuf {
+	if dev.MemIOType() != IOTypeMMAP && dev.MemIOType() != IOTypeUserPtr && dev.MemIOType() != IOTypeDMABuf {
 		return RequestBuffers{}, fmt.Errorf("reset buffers: %w", ErrorUnsupported)
 	}
 	var req C.struct_v4l2_requestbuffers
@@ -309,6 +309,16 @@ func MapMemoryBuffers(dev StreamingDevice) ([][]byte, error) {
 	return buffers, nil
 }
 
+// AllocateUserBuffers creates application-managed buffers for USERPTR streaming.
+// Each buffer is allocated with the specified size (typically pixFormat.SizeImage).
+func AllocateUserBuffers(count int, size uint32) [][]byte {
+	buffers := make([][]byte, count)
+	for i := range buffers {
+		buffers[i] = make([]byte, size)
+	}
+	return buffers
+}
+
 // unmapMemoryBuffer removes the buffer that was previously mapped.
 func unmapMemoryBuffer(buf []byte) error {
 	if err := sys.Munmap(buf); err != nil {
@@ -342,6 +352,24 @@ func QueueBuffer(fd uintptr, ioType IOType, bufType BufType, index uint32) (Buff
 
 	if err := send(fd, C.VIDIOC_QBUF, uintptr(unsafe.Pointer(&v4l2Buf))); err != nil {
 		return Buffer{}, fmt.Errorf("buffer queue: %w", err)
+	}
+
+	return makeBuffer(v4l2Buf), nil
+}
+
+// QueueBufferUserPtr enqueues a user-pointer buffer in the device driver.
+// The application provides the buffer address and length. Used with IOTypeUserPtr streaming.
+// https://www.kernel.org/doc/html/latest/userspace-api/media/v4l/vidioc-qbuf.html#vidioc-qbuf
+func QueueBufferUserPtr(fd uintptr, bufType BufType, index uint32, ptr uintptr, length uint32) (Buffer, error) {
+	var v4l2Buf C.struct_v4l2_buffer
+	v4l2Buf._type = C.uint(bufType)
+	v4l2Buf.memory = C.uint(IOTypeUserPtr)
+	v4l2Buf.index = C.uint(index)
+	v4l2Buf.length = C.uint(length)
+	*(*C.ulong)(unsafe.Pointer(&v4l2Buf.m[0])) = C.ulong(ptr)
+
+	if err := send(fd, C.VIDIOC_QBUF, uintptr(unsafe.Pointer(&v4l2Buf))); err != nil {
+		return Buffer{}, fmt.Errorf("buffer queue userptr: %w", err)
 	}
 
 	return makeBuffer(v4l2Buf), nil


### PR DESCRIPTION
  This PR (fixes #115 ) adds User Pointer (USERPTR) streaming input in addition to MMAP.

  `USERPTR` lets the application allocate its own buffers instead of using kernel-mapped memory. The underlying and the device API stay  identical — `Start` → `GetFrames`/`GetOutput` → `Stop` work the same regardless of which buffer mode is used.

```go
  dev, _ := device.Open("/dev/video0",
      device.WithIOType(v4l2.IOTypeUserPtr),
      device.WithBufferSize(4),
  )
  dev.Start(ctx)
  for frame := range dev.GetFrames() { ... }
  dev.Stop()
```