### PR TITLE
issue-119: Support DMA-BUF Streaming Input

### DIFF
--- a/device/capture_bytes.go
+++ b/device/capture_bytes.go
@@ -121,6 +121,8 @@ func (d *Device) startRawBytesCapture() {
 				case v4l2.IOTypeUserPtr:
 					ptr := uintptr(unsafe.Pointer(&d.buffers[buff.Index][0]))
 					_, queueErr = v4l2.QueueBufferUserPtr(fd, bufType, buff.Index, ptr, uint32(len(d.buffers[buff.Index])))
+				case v4l2.IOTypeDMABuf:
+					_, queueErr = v4l2.QueueBufferDMABuf(fd, bufType, buff.Index, d.dmabufFDs[buff.Index], uint32(len(d.buffers[buff.Index])))
 				default:
 					_, queueErr = v4l2.QueueBuffer(fd, ioMemType, bufType, buff.Index)
 				}

--- a/device/capture_frames.go
+++ b/device/capture_frames.go
@@ -120,6 +120,8 @@ func (d *Device) startFramesCapture() {
 				case v4l2.IOTypeUserPtr:
 					ptr := uintptr(unsafe.Pointer(&d.buffers[buff.Index][0]))
 					_, queueErr = v4l2.QueueBufferUserPtr(fd, bufType, buff.Index, ptr, uint32(len(d.buffers[buff.Index])))
+				case v4l2.IOTypeDMABuf:
+					_, queueErr = v4l2.QueueBufferDMABuf(fd, bufType, buff.Index, d.dmabufFDs[buff.Index], uint32(len(d.buffers[buff.Index])))
 				default:
 					_, queueErr = v4l2.QueueBuffer(fd, ioMemType, bufType, buff.Index)
 				}

--- a/device/device.go
+++ b/device/device.go
@@ -87,6 +87,10 @@ type Device struct {
 
 	// readSeq is a monotonically increasing frame counter for ReadFrame()
 	readSeq uint32
+
+	// dmabufFDs holds DMA-BUF file descriptors for import mode.
+	// Set via AddDMABufferFDs() before Start().
+	dmabufFDs []int32
 }
 
 // Open opens a V4L2 video device at the specified path and prepares it for use.
@@ -207,6 +211,8 @@ func Open(path string, options ...Option) (*Device, error) {
 		switch dev.config.ioType {
 		case v4l2.IOTypeUserPtr:
 			// user explicitly selected USERPTR
+		case v4l2.IOTypeDMABuf:
+			// user explicitly selected DMABUF
 		default:
 			dev.config.ioType = v4l2.IOTypeMMAP
 		}
@@ -256,6 +262,30 @@ func (d *Device) Close() error {
 		}
 	}
 	return v4l2.CloseDevice(d.fd)
+}
+
+// AddDMABufferFDs provides DMA-BUF file descriptors for import mode.
+// Call this after Open() and before Start(). Each fd corresponds to a buffer
+// index. The number of fds should match the buffer count (WithBufferSize).
+// Can be called multiple times to append fds incrementally.
+//
+// File descriptors typically come from another subsystem (GPU, DRM, another
+// V4L2 device) via their export APIs.
+func (d *Device) AddDMABufferFDs(fds ...int32) {
+	d.dmabufFDs = append(d.dmabufFDs, fds...)
+}
+
+// ExportBuffer exports a MMAP buffer as a DMA-BUF file descriptor.
+// The buffer at the given index must have been allocated via MMAP streaming
+// (the device must be started with Start() first).
+// The returned fd can be passed to other subsystems (GPU, DRM, other V4L2 devices).
+//
+// flags is typically 0 or syscall.O_RDONLY/syscall.O_RDWR for access control.
+func (d *Device) ExportBuffer(index uint32, flags uint32) (int32, error) {
+	if d.config.ioType != v4l2.IOTypeMMAP {
+		return 0, fmt.Errorf("device: ExportBuffer requires MMAP IO type")
+	}
+	return v4l2.ExportBuffer(d.fd, d.bufType, index, flags)
 }
 
 // Name returns the file system path of the device (e.g., "/dev/video0").
@@ -1632,6 +1662,26 @@ func (d *Device) Start(ctx context.Context) error {
 	switch d.config.ioType {
 	case v4l2.IOTypeUserPtr:
 		d.buffers = v4l2.AllocateUserBuffers(int(d.config.bufSize), d.config.pixFormat.SizeImage)
+	case v4l2.IOTypeDMABuf:
+		if len(d.dmabufFDs) == 0 {
+			d.streaming.Store(false)
+			return fmt.Errorf("device: DMA-BUF mode requires file descriptors via AddDMABufferFDs")
+		}
+		if len(d.dmabufFDs) < int(d.config.bufSize) {
+			d.streaming.Store(false)
+			return fmt.Errorf("device: DMA-BUF mode requires %d fds, got %d", d.config.bufSize, len(d.dmabufFDs))
+		}
+		// mmap the DMA-BUF fds so capture loops can read frame data
+		d.buffers = make([][]byte, d.config.bufSize)
+		for i := 0; i < int(d.config.bufSize); i++ {
+			buf, err := sys.Mmap(int(d.dmabufFDs[i]), 0, int(d.config.pixFormat.SizeImage),
+				sys.PROT_READ|sys.PROT_WRITE, sys.MAP_SHARED)
+			if err != nil {
+				d.streaming.Store(false)
+				return fmt.Errorf("device: mmap dmabuf fd %d: %w", d.dmabufFDs[i], err)
+			}
+			d.buffers[i] = buf
+		}
 	default: // IOTypeMMAP
 		if d.buffers, err = v4l2.MapMemoryBuffers(d); err != nil {
 			return fmt.Errorf("device: make mapped buffers: %s", err)
@@ -1644,6 +1694,11 @@ func (d *Device) Start(ctx context.Context) error {
 		case v4l2.IOTypeUserPtr:
 			ptr := uintptr(unsafe.Pointer(&d.buffers[i][0]))
 			if _, err := v4l2.QueueBufferUserPtr(d.fd, d.bufType, uint32(i), ptr, uint32(len(d.buffers[i]))); err != nil {
+				d.streaming.Store(false)
+				return fmt.Errorf("device: buffer queueing: %w", err)
+			}
+		case v4l2.IOTypeDMABuf:
+			if _, err := v4l2.QueueBufferDMABuf(d.fd, d.bufType, uint32(i), d.dmabufFDs[i], d.config.pixFormat.SizeImage); err != nil {
 				d.streaming.Store(false)
 				return fmt.Errorf("device: buffer queueing: %w", err)
 			}
@@ -1708,9 +1763,17 @@ func (d *Device) Stop() error {
 		}
 	}
 
-	if d.config.ioType == v4l2.IOTypeMMAP {
+	switch d.config.ioType {
+	case v4l2.IOTypeMMAP:
 		if err := v4l2.UnmapMemoryBuffers(d); err != nil {
 			return fmt.Errorf("device: stop: %w", err)
+		}
+	case v4l2.IOTypeDMABuf:
+		// unmap the mmap'd views of DMA-BUF fds
+		for _, buf := range d.buffers {
+			if buf != nil {
+				sys.Munmap(buf)
+			}
 		}
 	}
 	if err := v4l2.StreamOff(d); err != nil {

--- a/device/device_config.go
+++ b/device/device_config.go
@@ -52,7 +52,7 @@ type Option func(*config)
 // Available I/O types:
 //   - IOTypeMMAP: Memory-mapped I/O (default, zero-copy from kernel)
 //   - IOTypeUserPtr: User pointer I/O (application-allocated buffers)
-//   - IOTypeDMABuf: DMA buffer sharing (not yet supported)
+//   - IOTypeDMABuf: DMA buffer sharing (zero-copy with GPU/DRM via file descriptors)
 //
 // Example:
 //

--- a/device/device_test.go
+++ b/device/device_test.go
@@ -897,3 +897,56 @@ func TestUserPtr_WithStreamingMethod(t *testing.T) {
 		t.Errorf("ioType = %d, want IOTypeUserPtr", cfg.ioType)
 	}
 }
+
+// TestWithIOType_DMABuf tests that WithIOType sets DMABuf correctly
+func TestWithIOType_DMABuf(t *testing.T) {
+	cfg := config{}
+	WithIOType(v4l2.IOTypeDMABuf)(&cfg)
+	if cfg.ioType != v4l2.IOTypeDMABuf {
+		t.Errorf("ioType = %d, want IOTypeDMABuf (%d)", cfg.ioType, v4l2.IOTypeDMABuf)
+	}
+}
+
+// TestDevice_AddDMABufferFDs tests that AddDMABufferFDs appends fds
+func TestDevice_AddDMABufferFDs(t *testing.T) {
+	dev := Device{}
+
+	dev.AddDMABufferFDs(10, 11)
+	if len(dev.dmabufFDs) != 2 {
+		t.Fatalf("dmabufFDs length = %d, want 2", len(dev.dmabufFDs))
+	}
+	if dev.dmabufFDs[0] != 10 || dev.dmabufFDs[1] != 11 {
+		t.Errorf("dmabufFDs = %v, want [10 11]", dev.dmabufFDs)
+	}
+
+	// Append more
+	dev.AddDMABufferFDs(12, 13)
+	if len(dev.dmabufFDs) != 4 {
+		t.Fatalf("dmabufFDs length = %d, want 4", len(dev.dmabufFDs))
+	}
+	if dev.dmabufFDs[2] != 12 || dev.dmabufFDs[3] != 13 {
+		t.Errorf("dmabufFDs = %v, want [10 11 12 13]", dev.dmabufFDs)
+	}
+}
+
+// TestDevice_ExportBuffer_RejectsNonMMAP tests ExportBuffer errors for non-MMAP devices
+func TestDevice_ExportBuffer_RejectsNonMMAP(t *testing.T) {
+	tests := []struct {
+		name   string
+		ioType v4l2.IOType
+	}{
+		{"UserPtr", v4l2.IOTypeUserPtr},
+		{"DMABuf", v4l2.IOTypeDMABuf},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dev := Device{
+				config: config{ioType: tt.ioType},
+			}
+			_, err := dev.ExportBuffer(0, 0)
+			if err == nil {
+				t.Error("ExportBuffer() should return error for non-MMAP IO type")
+			}
+		})
+	}
+}

--- a/examples/dmabuf_export/README.md
+++ b/examples/dmabuf_export/README.md
@@ -1,0 +1,52 @@
+# DMA-BUF Export Example
+
+Demonstrates exporting V4L2 MMAP buffers as DMA-BUF file descriptors for zero-copy sharing with other subsystems (GPU, DRM, other V4L2 devices).
+
+## DMA-BUF Overview
+
+DMA-BUF is a Linux kernel mechanism for sharing buffers between devices via file descriptors:
+
+- **Export**: Share V4L2 capture buffers with GPU/DRM (`VIDIOC_EXPBUF`)
+- **Import**: Use external DMA-BUF fds for V4L2 capture (`V4L2_MEMORY_DMABUF`)
+
+This example demonstrates the **export** path.
+
+## Usage
+
+```bash
+# Export 4 MMAP buffers as DMA-BUF fds and capture 5 frames
+go run . -d /dev/video0
+
+# With custom buffer count
+go run . -d /dev/video0 -b 8
+```
+
+## Flags
+
+- `-d` — Device path (default: `/dev/video0`)
+- `-b` — Number of buffers (default: 4)
+
+## Output
+
+```
+Buffer 0 exported as DMA-BUF fd=5
+Buffer 1 exported as DMA-BUF fd=6
+Buffer 2 exported as DMA-BUF fd=7
+Buffer 3 exported as DMA-BUF fd=8
+Frame 0: seq=0, 12543 bytes
+Frame 1: seq=1, 12601 bytes
+```
+
+## Import Mode
+
+For DMA-BUF import (receiving fds from another subsystem):
+
+```go
+dev, _ := device.Open("/dev/video0",
+    device.WithIOType(v4l2.IOTypeDMABuf),
+    device.WithBufferSize(4),
+)
+dev.AddDMABufferFDs(gpuFD0, gpuFD1, gpuFD2, gpuFD3)
+dev.Start(ctx)
+for frame := range dev.GetFrames() { ... }
+```

--- a/examples/dmabuf_export/main.go
+++ b/examples/dmabuf_export/main.go
@@ -1,0 +1,72 @@
+// dmabuf_export demonstrates exporting V4L2 MMAP buffers as DMA-BUF file descriptors.
+//
+// This allows other subsystems (GPU, DRM, other V4L2 devices) to access the
+// captured video frames via zero-copy buffer sharing.
+//
+// Usage:
+//
+//	dmabuf_export -d /dev/video0
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/vladimirvivien/go4vl/device"
+	"github.com/vladimirvivien/go4vl/v4l2"
+)
+
+func main() {
+	devName := "/dev/video0"
+	bufCount := 4
+	flag.StringVar(&devName, "d", devName, "device name (path)")
+	flag.IntVar(&bufCount, "b", bufCount, "number of buffers")
+	flag.Parse()
+
+	dev, err := device.Open(
+		devName,
+		device.WithPixFormat(v4l2.PixFormat{
+			PixelFormat: v4l2.PixelFmtMJPEG,
+			Width:       640,
+			Height:      480,
+		}),
+		device.WithBufferSize(uint32(bufCount)),
+	)
+	if err != nil {
+		log.Fatalf("failed to open device: %s", err)
+	}
+	defer dev.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := dev.Start(ctx); err != nil {
+		log.Fatalf("failed to start stream: %s", err)
+	}
+	defer dev.Stop()
+
+	// Export each MMAP buffer as a DMA-BUF fd
+	for i := 0; i < bufCount; i++ {
+		fd, err := dev.ExportBuffer(uint32(i), 0)
+		if err != nil {
+			log.Fatalf("failed to export buffer %d: %s", i, err)
+		}
+		fmt.Printf("Buffer %d exported as DMA-BUF fd=%d\n", i, fd)
+		// In a real application, pass fd to GPU/DRM/other device:
+		//   gpu.ImportBuffer(fd)
+	}
+
+	// Capture a few frames to show streaming still works
+	count := 0
+	for frame := range dev.GetFrames() {
+		fmt.Printf("Frame %d: seq=%d, %d bytes\n", count, frame.Sequence, len(frame.Data))
+		frame.Release()
+		count++
+		if count >= 5 {
+			break
+		}
+	}
+}

--- a/test/device_test.go
+++ b/test/device_test.go
@@ -719,6 +719,76 @@ func TestDevice_UserPtr(t *testing.T) {
 	})
 }
 
+// TestDevice_DMABuf_Export tests exporting MMAP buffers as DMA-BUF fds.
+func TestDevice_DMABuf_Export(t *testing.T) {
+	devicePath := RequireV4L2Testing(t)
+
+	dev := OpenDeviceOrSkip(t, devicePath,
+		device.WithBufferSize(2),
+	)
+
+	if !dev.Capability().IsStreamingSupported() {
+		t.Skip("Device does not support streaming IO")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := dev.Start(ctx); err != nil {
+		if isDeviceError(err) {
+			t.Skipf("Streaming not functional on this device: %v", err)
+		}
+		t.Fatalf("Start() = %v", err)
+	}
+	defer dev.Stop()
+
+	fd, err := dev.ExportBuffer(0, 0)
+	if err != nil {
+		if isDeviceError(err) {
+			t.Skipf("ExportBuffer not functional on this device: %v", err)
+		}
+		t.Fatalf("ExportBuffer() = %v", err)
+	}
+	if fd <= 0 {
+		t.Errorf("ExportBuffer() returned fd=%d, want > 0", fd)
+	}
+	t.Logf("Exported buffer 0 as DMA-BUF fd=%d", fd)
+}
+
+// TestDevice_DMABuf_Import tests DMA-BUF import mode.
+// Likely skips on v4l2loopback which doesn't support DMA-BUF.
+func TestDevice_DMABuf_Import(t *testing.T) {
+	devicePath := RequireV4L2Testing(t)
+
+	dev := OpenDeviceOrSkip(t, devicePath,
+		device.WithIOType(v4l2.IOTypeDMABuf),
+		device.WithBufferSize(2),
+	)
+
+	if !dev.Capability().IsStreamingSupported() {
+		t.Skip("Device does not support streaming IO")
+	}
+
+	// DMA-BUF import requires external fds — we don't have any in CI,
+	// so just verify Start() fails with a clear error about missing fds
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := dev.Start(ctx)
+	if err == nil {
+		dev.Stop()
+		t.Error("Start() should fail without DMA-BUF fds")
+		return
+	}
+	if !strings.Contains(err.Error(), "AddDMABufferFDs") {
+		if isDeviceError(err) {
+			t.Skipf("DMA-BUF not functional on this device: %v", err)
+		}
+		t.Errorf("Start() error = %v, expected error mentioning AddDMABufferFDs", err)
+	}
+	t.Logf("Start() correctly returned: %v", err)
+}
+
 // isDeviceError returns true for device errors that indicate the I/O method
 // is not functional (e.g., loopback device with no data source, or unsupported mode).
 func isDeviceError(err error) bool {
@@ -727,5 +797,6 @@ func isDeviceError(err error) bool {
 		strings.Contains(msg, "device or resource busy") ||
 		strings.Contains(msg, "bad file descriptor") ||
 		strings.Contains(msg, "bad argument") ||
-		strings.Contains(msg, "type not supported")
+		strings.Contains(msg, "type not supported") ||
+		strings.Contains(msg, "system error")
 }

--- a/v4l2/streaming.go
+++ b/v4l2/streaming.go
@@ -375,6 +375,40 @@ func QueueBufferUserPtr(fd uintptr, bufType BufType, index uint32, ptr uintptr, 
 	return makeBuffer(v4l2Buf), nil
 }
 
+// QueueBufferDMABuf enqueues a DMA-BUF buffer in the device driver.
+// The application provides the DMA-BUF file descriptor and buffer length.
+// https://www.kernel.org/doc/html/latest/userspace-api/media/v4l/vidioc-qbuf.html#vidioc-qbuf
+func QueueBufferDMABuf(fd uintptr, bufType BufType, index uint32, dmabufFD int32, length uint32) (Buffer, error) {
+	var v4l2Buf C.struct_v4l2_buffer
+	v4l2Buf._type = C.uint(bufType)
+	v4l2Buf.memory = C.uint(IOTypeDMABuf)
+	v4l2Buf.index = C.uint(index)
+	v4l2Buf.length = C.uint(length)
+	*(*C.int)(unsafe.Pointer(&v4l2Buf.m[0])) = C.int(dmabufFD)
+
+	if err := send(fd, C.VIDIOC_QBUF, uintptr(unsafe.Pointer(&v4l2Buf))); err != nil {
+		return Buffer{}, fmt.Errorf("buffer queue dmabuf: %w", err)
+	}
+
+	return makeBuffer(v4l2Buf), nil
+}
+
+// ExportBuffer exports a V4L2 buffer as a DMA-BUF file descriptor.
+// The buffer must have been allocated with MMAP. The returned fd can be
+// passed to other subsystems (GPU, DRM, other V4L2 devices).
+// https://www.kernel.org/doc/html/latest/userspace-api/media/v4l/vidioc-expbuf.html
+func ExportBuffer(devFD uintptr, bufType BufType, index uint32, flags uint32) (int32, error) {
+	var exp C.struct_v4l2_exportbuffer
+	exp._type = C.uint(bufType)
+	exp.index = C.uint(index)
+	exp.flags = C.uint(flags)
+
+	if err := send(devFD, C.VIDIOC_EXPBUF, uintptr(unsafe.Pointer(&exp))); err != nil {
+		return 0, fmt.Errorf("export buffer: %w", err)
+	}
+	return int32(exp.fd), nil
+}
+
 // DequeueBuffer dequeues a buffer in the device driver, marking it as consumed by the application,
 // when using either memory map, user pointer, or DMA buffers. Buffer is returned with
 // additional information about the dequeued buffer.


### PR DESCRIPTION
This PR (fixes #119) adds DMA-BUF support for zero-copy buffer sharing between V4L2 Go apps and
  other subsystems (GPU, DRM, other V4L2 devices).

```go
  Import — capture into externally-provided DMA-BUF buffers:
  dev, _ := device.Open("/dev/video0",
      device.WithIOType(v4l2.IOTypeDMABuf),
      device.WithBufferSize(4),
  )
  dev.AddDMABufferFDs(gpuFD0, gpuFD1, gpuFD2, gpuFD3)
  dev.Start(ctx)
  for frame := range dev.GetFrames() { ... }
```
Export — share MMAP buffers as DMA-BUF fds for other devices:
```go
  fd, _ := dev.ExportBuffer(0, 0)  // VIDIOC_EXPBUF
  // pass fd to GPU/DRM
```